### PR TITLE
feat: Paging 3 in Compose guardrails (4.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "compose-agent",
-      "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, animation APIs, performance-aware modifiers, Navigation 3, coroutines on lifecycle, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin.",
+      "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, animation APIs, Paging 3 in Compose, performance-aware modifiers, Navigation 3, coroutines on lifecycle, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin.",
       "author": { "name": "Ivan Morgillo" },
       "category": "development",
       "source": {
@@ -16,11 +16,11 @@
         "url": "https://github.com/hamen/compose_skill.git",
         "path": "skills/compose-agent"
       },
-      "tags": ["android", "jetpack-compose", "kotlin", "animation", "ui-testing", "focus", "kotlin-multiplatform", "splash-screen", "agent-skill"]
+      "tags": ["android", "jetpack-compose", "kotlin", "animation", "paging", "ui-testing", "focus", "kotlin-multiplatform", "splash-screen", "agent-skill"]
     },
     {
       "name": "jetpack-compose-audit",
-      "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score with every deduction cited against developer.android.com and coverage notes for animation performance, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
+      "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score with every deduction cited against developer.android.com and coverage notes for animation performance, Paging 3 list/load-state correctness, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
       "author": { "name": "Ivan Morgillo" },
       "category": "development",
       "source": {
@@ -28,7 +28,7 @@
         "url": "https://github.com/hamen/compose_skill.git",
         "path": "skills/jetpack-compose-audit"
       },
-      "tags": ["android", "jetpack-compose", "audit", "performance", "animation", "ui-testing", "focus", "kotlin-multiplatform", "splash-screen"]
+      "tags": ["android", "jetpack-compose", "audit", "performance", "animation", "paging", "ui-testing", "focus", "kotlin-multiplatform", "splash-screen"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full release history for the Compose Skill Suite. The newest release is summarised under **What's new** in the [README](./README.md).
 
-### 4.2.0 — 2026-06-17
+### 4.2.0 — 2026-06-17 (release candidate — convergence testing before GA tag)
 
 **Paging 3 in Compose — guardrails for paged lazy lists.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Full release history for the Compose Skill Suite. The newest release is summarised under **What's new** in the [README](./README.md).
 
+### 4.2.0 — 2026-06-17
+
+**Paging 3 in Compose — guardrails for paged lazy lists.**
+
+- **New reference.** Added `skills/compose-agent/references/paging.md` — when to page vs plain lists, `collectAsLazyPagingItems`, stable `itemKey`, `LoadState` UI, user-driven `refresh()` / `retry()`, anti-pattern checklist. No `PagingSource` / RemoteMediator cookbook.
+- **Review wiring.** `compose-agent` review step #14, core instruction, authoring guardrail, manifest keyword `paging`.
+- **Audit hooks.** `jetpack-compose-audit` adds paging search heuristic plus **Paging list correctness** (Performance) and **Paging load-state handling** (State) report signals — no fifth score category.
+- **Planning.** [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md) records scope and multi-agent validation plan.
+- **Versions.** `compose-agent` → `4.2.0`. `jetpack-compose-audit` → `4.2.0`.
+
 ### 4.1.2 — 2026-06-14
 
 **Repo hygiene — evals as data, changelog split out, launch cruft removed.**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude%20Code-plugin-111827">
 </p>
 
-**Version 4.2.0 · released 2026-06-17** — Paging 3 in Compose: new `paging.md` reference (LLM guardrails, not API tour), audit hooks under existing Performance/State categories, planning doc at [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md). Multi-agent convergence testing planned before GA tag. Both skills ship as `4.2.0`.
+**Version 4.2.0 · 2026-06-17 (release candidate — convergence testing before GA tag)** — Paging 3 in Compose: new `paging.md` reference (LLM guardrails, not API tour), audit hooks under existing Performance/State categories, planning doc at [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md). Multi-agent convergence testing planned before GA tag. Both skills ship as `4.2.0`.
 
 > Find out where your Compose app is burning frames, by how much, and what to change to win them back — measured against real compiler data, not vibes.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="./bin/ci"><img alt="bin/ci passing" src="https://img.shields.io/badge/bin%2Fci-passing-2ea043"></a>
-  <a href="https://github.com/hamen/compose_skill/releases/tag/v4.2.0"><img alt="Release" src="https://img.shields.io/github/v/release/hamen/compose_skill?color=2f80ed&label=release"></a>
+  <a href="https://github.com/hamen/compose_skill/releases"><img alt="Release" src="https://img.shields.io/github/v/release/hamen/compose_skill?color=2f80ed&label=release"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/hamen/compose_skill?color=0a7f60"></a>
   <img alt="Skills" src="https://img.shields.io/badge/skills-2-7c3aed">
   <img alt="Compose animation ready" src="https://img.shields.io/badge/Compose-animation%20ready-f97316">

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 <p align="center">
   <a href="./bin/ci"><img alt="bin/ci passing" src="https://img.shields.io/badge/bin%2Fci-passing-2ea043"></a>
-  <a href="https://github.com/hamen/compose_skill/releases/tag/v4.1.2"><img alt="Release" src="https://img.shields.io/github/v/release/hamen/compose_skill?color=2f80ed&label=release"></a>
+  <a href="https://github.com/hamen/compose_skill/releases/tag/v4.2.0"><img alt="Release" src="https://img.shields.io/github/v/release/hamen/compose_skill?color=2f80ed&label=release"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/hamen/compose_skill?color=0a7f60"></a>
   <img alt="Skills" src="https://img.shields.io/badge/skills-2-7c3aed">
   <img alt="Compose animation ready" src="https://img.shields.io/badge/Compose-animation%20ready-f97316">
   <img alt="Claude Code plugin" src="https://img.shields.io/badge/Claude%20Code-plugin-111827">
 </p>
 
-**Version 4.1.2 · released 2026-06-14** — Repo hygiene patch: the 4.1.0 eval scenarios are now a machine-readable [`evals.json`](./skills/jetpack-compose-audit/evals/evals.json) inside the audit skill instead of prose in `docs/`, the full release history moved to [`CHANGELOG.md`](./CHANGELOG.md), and the launch-tweet drafts were dropped from `docs/`. No skill-behavior changes. Both skills ship as `4.1.2`.
+**Version 4.2.0 · released 2026-06-17** — Paging 3 in Compose: new `paging.md` reference (LLM guardrails, not API tour), audit hooks under existing Performance/State categories, planning doc at [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md). Multi-agent convergence testing planned before GA tag. Both skills ship as `4.2.0`.
 
 > Find out where your Compose app is burning frames, by how much, and what to change to win them back — measured against real compiler data, not vibes.
 
@@ -27,17 +27,17 @@ Authored and cross-reviewed with every frontier model — Claude Opus 4.8, GPT-5
 
 ## What's new
 
-### 4.1.2 — 2026-06-14
+### 4.2.0 — 2026-06-17
 
-**Repo hygiene — evals as data, changelog split out, launch cruft removed.**
+**Paging 3 in Compose — guardrails for paged lazy lists.**
 
-- **Evals are machine-readable now.** The 4.1.0 acceptance scenarios moved from prose in `docs/evals-4.1.0.md` to [`skills/jetpack-compose-audit/evals/evals.json`](./skills/jetpack-compose-audit/evals/evals.json) — `skill_name` + ten `{prompt, expected_output, expectations}` cases, the canonical eval layout (an `evals/` directory inside the skill).
-- **Changelog split out.** Full release history now lives in [`CHANGELOG.md`](./CHANGELOG.md); this README keeps only the latest release here.
-- **Dropped launch cruft.** Removed the launch-tweet drafts (`docs/tweet-*.md`) from the repo; release notes stay in `docs/`.
-- **No behavior change.** Skill guidance, audit scoring, and search leads are identical to `4.1.1`.
-- **Versions.** `compose-agent` → `4.1.2`. `jetpack-compose-audit` → `4.1.2`.
+- **New reference.** [`skills/compose-agent/references/paging.md`](./skills/compose-agent/references/paging.md) — stable keys on `LazyPagingItems`, `LoadState` branches, user-driven refresh/retry. Targets LLM mistakes, not `PagingSource` implementation.
+- **Review wiring.** New step #14 in `compose-agent`; scoped entry `compose-agent focus on paging`.
+- **Audit hooks.** Report signals **Paging list correctness** (Performance) and **Paging load-state handling** (State) — no fifth score category.
+- **Plan.** [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md) includes the multi-agent validation checklist.
+- **Versions.** `compose-agent` → `4.2.0`. `jetpack-compose-audit` → `4.2.0`.
 
-For the full release history, see [CHANGELOG.md](./CHANGELOG.md).
+For release detail, see [`docs/release-notes-4.2.0.md`](./docs/release-notes-4.2.0.md). Full history: [CHANGELOG.md](./CHANGELOG.md).
 
 ---
 
@@ -339,6 +339,7 @@ The reference files are deliberately loadable in isolation. Scoping a review to 
 | focus, keyboard, D-pad, TV/desktop navigation | `compose-agent focus on focus` |
 | KMP/CMP source sets, `expect`/`actual`, platform interop | `compose-agent focus on kmp` |
 | animation API choice, lifecycle, labels, phase-correct reads | `compose-agent focus on animation` |
+| Paging 3 in Compose (`LazyPagingItems`, keys, `LoadState`) | `compose-agent focus on paging` |
 | deprecated / soft-deprecated APIs and Android launch resources | `compose-agent focus on api` |
 | idiomatic Kotlin / Android style | `compose-agent focus on kotlin` |
 
@@ -382,6 +383,7 @@ skills/compose-agent/
     focus.md                     FocusRequester, keyboard / D-pad input, focus restoration, focus tests
     kmp.md                       KMP/CMP boundaries, expect/actual, interfaces, platform leaf composables
     animation.md                 animation API choice, lifecycle, labels, deferred animated reads
+    paging.md                    Paging 3 in Compose: keys, LoadState, refresh/retry guardrails
     kotlin.md                    Kotlin conventions + Android Kotlin style the LLM misses
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Authored and cross-reviewed with every frontier model — Claude Opus 4.8, GPT-5
 
 **Paging 3 in Compose — guardrails for paged lazy lists.**
 
-- **New reference.** [`skills/compose-agent/references/paging.md`](./skills/compose-agent/references/paging.md) — stable keys on `LazyPagingItems`, `LoadState` branches, user-driven refresh/retry. Targets LLM mistakes, not `PagingSource` implementation.
+- **New reference.** [`skills/compose-agent/references/paging.md`](./skills/compose-agent/references/paging.md) — decision table, golden path, stable keys, `LoadState`, hard nos. Targets LLM mistakes, not `PagingSource` implementation.
 - **Review wiring.** New step #14 in `compose-agent`; scoped entry `compose-agent focus on paging`.
 - **Audit hooks.** Report signals **Paging list correctness** (Performance) and **Paging load-state handling** (State) — no fifth score category.
 - **Plan.** [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md) includes the multi-agent validation checklist.

--- a/bin/ci
+++ b/bin/ci
@@ -132,6 +132,28 @@ if (!readFileSync('skills/compose-agent/references/performance.md', 'utf8').incl
   throw new Error('compose-agent performance.md must cross-link references/animation.md');
 }
 
+if (
+  !composeAgentDocs.includes('references/paging.md') ||
+  !composeAgentDocs.includes('collectAsLazyPagingItems') ||
+  !composeAgentDocs.includes('itemKey') ||
+  !composeAgentDocs.includes('LoadState')
+) {
+  throw new Error('compose-agent paging reference must cover collectAsLazyPagingItems, itemKey, and LoadState');
+}
+
+if (!readFileSync('skills/compose-agent/references/performance.md', 'utf8').includes('references/paging.md')) {
+  throw new Error('compose-agent performance.md must cross-link references/paging.md');
+}
+
+if (
+  !auditDocs.includes('Paging list correctness') ||
+  !auditDocs.includes('Paging load-state handling') ||
+  !auditDocs.includes('Paging list signals') ||
+  !auditDocs.includes('Paging load-state signals')
+) {
+  throw new Error('jetpack-compose-audit docs must surface paging findings in Performance and State report sections');
+}
+
 const auditSkill = readFileSync('skills/jetpack-compose-audit/SKILL.md', 'utf8');
 const auditVersion = JSON.parse(readFileSync('skills/jetpack-compose-audit/.claude-plugin/plugin.json', 'utf8')).version;
 if (!auditSkill.includes(`**Skill version:** ${auditVersion}`)) {

--- a/bin/ci
+++ b/bin/ci
@@ -136,9 +136,11 @@ if (
   !composeAgentDocs.includes('references/paging.md') ||
   !composeAgentDocs.includes('collectAsLazyPagingItems') ||
   !composeAgentDocs.includes('itemKey') ||
-  !composeAgentDocs.includes('LoadState')
+  !composeAgentDocs.includes('LoadState') ||
+  !composeAgentDocs.includes('Golden Path') ||
+  !composeAgentDocs.includes('PagingData.from')
 ) {
-  throw new Error('compose-agent paging reference must cover collectAsLazyPagingItems, itemKey, and LoadState');
+  throw new Error('compose-agent paging reference must cover collectAsLazyPagingItems, itemKey, LoadState, golden path, and PagingData.from preview pattern');
 }
 
 if (!readFileSync('skills/compose-agent/references/performance.md', 'utf8').includes('references/paging.md')) {

--- a/bin/ci
+++ b/bin/ci
@@ -151,9 +151,10 @@ if (
   !auditDocs.includes('Paging list correctness') ||
   !auditDocs.includes('Paging load-state handling') ||
   !auditDocs.includes('Paging list signals') ||
-  !auditDocs.includes('Paging load-state signals')
+  !auditDocs.includes('Paging load-state signals') ||
+  !auditDocs.includes('Paging side-effect signals')
 ) {
-  throw new Error('jetpack-compose-audit docs must surface paging findings in Performance and State report sections');
+  throw new Error('jetpack-compose-audit docs must surface paging findings in Performance, State, and Side Effects report sections');
 }
 
 const auditSkill = readFileSync('skills/jetpack-compose-audit/SKILL.md', 'utf8');

--- a/docs/animation-skill-notes.md
+++ b/docs/animation-skill-notes.md
@@ -48,7 +48,7 @@ We verified the gap is real inside `compose-agent`: animation APIs appeared only
 1. **Should the audit ever add a standalone Animation category?** Leaning no. The current rubric already scores concrete defects in the existing categories, and adding a fifth category would make historical scores harder to compare.
 2. **Shared-element transitions** — own reference file, or a section in `animation.md`? It pulls in `SharedTransitionScope`, `AnimatedVisibilityScope`, `Modifier.sharedElement`, and has its own LLM tells (forgetting the scopes, key mismatches). Probably earns its own file once we see it requested.
 3. **Next steal from the issue tracker.** Ranked from the same mining pass:
-   - **Paging 3 in Compose** (#11, #25) — `collectAsLazyPagingItems`, `LazyPagingItems`, loadState handling, item keys. Real gap, medium size. Strongest next candidate.
+   - **Paging 3 in Compose** (#11, #25) — **shipped in 4.2.0** as `references/paging.md`; see `docs/paging-skill-plan.md` and convergence testing plan in `docs/release-notes-4.2.0.md`.
    - **(declined by us)** Architecture per-layer (#9), XML→Compose (#38) — both intentionally dropped: DAC covers architecture, and XML is dead weight in 2026.
 4. **Provenance signaling.** Worth being louder (README? per-reference footer?) that these references are sourced from declined upstream requests? Good marketing story, but don't want it to read as adversarial toward the Android team. Current choice: a single neutral line in the changelog. Revisit.
 

--- a/docs/paging-skill-plan.md
+++ b/docs/paging-skill-plan.md
@@ -1,0 +1,106 @@
+# Paging reference — implementation plan
+
+Status: **in progress (4.2.0 branch)**  
+Last updated: 2026-06-17.
+
+This document is the plan for extending Compose Skill Suite with Paging 3 in Compose coverage. It follows the same product thesis as `animation.md` and `navigation.md`: **guardrails for LLM mistakes**, not an API encyclopedia.
+
+## Problem statement
+
+When a screen uses `PagingData` / `LazyPagingItems`, agents today have no dedicated reference. They fall back to generic lazy-list guidance and improvise:
+
+- `items(lazyPagingItems.itemCount)` without stable `key`
+- ignoring `LoadState` (blank screens, infinite spinners, silent errors)
+- treating `LazyPagingItems` like an in-memory `List`
+- refresh canRefresh()` / `refresh()` wired from composition instead of user events
+- keys from list index or `hashCode()` on paginated, merge-prone streams
+
+These are the same failure modes as lazy-list bugs, but with paging-specific triggers (append load, refresh, placeholder gaps, duplicate IDs across pages).
+
+## Product decisions (locked)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| New audit category? | **No** | Same as animation 4.0 — keeps 0–100 scores comparable |
+| Where defects score | Performance (keys, list misuse), State (LoadState), Side effects (refresh in composition) | Root-cause mapping |
+| Scope of `paging.md` | Compose UI layer only | No `PagingSource` / RemoteMediator implementation guide |
+| Style | LLM tells + guardrails + official links | Matches `animation.md`, not third-party cookbook |
+| Version bump | **4.2.0** both skills | New reference + audit hooks = minor release |
+
+## Deliverables
+
+### `compose-agent` 4.2.0
+
+- [x] `skills/compose-agent/references/paging.md`
+- [x] Review step #14 in `SKILL.md` (before Kotlin style pass)
+- [x] Core instruction + authoring-mode guardrail for paging screens
+- [x] References list entry + description / `argument-hint` / plugin keywords
+- [x] Cross-link from `performance.md` → `paging.md`
+
+### `jetpack-compose-audit` 4.2.0
+
+- [x] `search-playbook.md` — Paging surface map + paging-list heuristic
+- [x] `scoring.md` — paging-specific deductions under existing categories
+- [x] `report-template.md` — **Paging list signals** (Performance) + **Paging state signals** (State)
+- [x] `SKILL.md` — category focus bullets mention paging where relevant
+- [x] `canonical-sources.md` — Paging 3 Compose official URLs
+
+### Repo hygiene
+
+- [x] `docs/release-notes-4.2.0.md`
+- [x] README What's new (4.2.0 stub)
+- [x] `CHANGELOG.md` entry
+- [x] `bin/ci` smoke checks for paging coverage
+- [x] Manifest versions → 4.2.0 (Claude + Cursor, both skills)
+
+## `paging.md` outline
+
+1. **When paging vs a normal list** — decision table
+2. **Collection** — `collectAsLazyPagingItems()` + lifecycle (`flowWithLifecycle` / ViewModel `cachedIn`)
+3. **Rendering** — `items(count = lazyPagingItems.itemCount, key = …)` pattern; never index-only keys
+4. **LoadState** — refresh / append / prepend; error + retry; empty vs loading vs content
+5. **Refresh** — user-driven `refresh()`; not from composition body
+6. **Anti-pattern checklist** — 8–10 LLM tells
+7. **Primary sources** — official Paging 3 Compose docs only
+
+## Explicitly out of scope (4.2.0)
+
+- Implementing `PagingSource`, `RemoteMediator`, Room + network offline-first
+- Paging unit/integration test suites
+- Comparing Paging vs hand-rolled infinite scroll
+- AOSP source receipts
+
+Revisit only if user demand or audit false-negative rate justifies it.
+
+## Audit signal mapping
+
+| Smell | Report section | Label |
+|-------|----------------|-------|
+| Missing / unstable `key` on `LazyPagingItems` | Performance | **Paging list correctness** |
+| `indexOf` / index keys on paginated stream | Performance | **Paging list correctness** |
+| Ignored `LoadState.Error` / no retry UI | State management | **Paging load-state handling** |
+| Spinner never dismissed (refresh stuck) | State management | **Paging load-state handling** |
+| `refresh()` / `retry()` from composition | Side effects | (existing side-effect language) |
+| Exposing raw `LazyPagingItems` from design-system API | Composable API quality | (existing API-shape language) |
+
+## Validation plan (post-merge)
+
+Multi-agent / multi-model convergence testing (manual, outside this PR):
+
+1. **Fixture repo** with deliberate paging bugs (no keys, ignored LoadState, composition refresh)
+2. Run **compose-agent** review on Claude, Codex, Cursor — expect paging step loaded + cited fixes
+3. Run **jetpack-compose-audit** — expect findings under Performance/State, not a fifth category
+4. **Negative control** — screen without paging should not hallucinate paging rules
+5. Collect disagreements → tune `paging.md` / heuristics in a follow-up patch
+
+Success criteria for 4.2.0 GA:
+
+- ≥3/3 agents flag key + LoadState bugs on fixture
+- 0/3 agents recommend implementing RemoteMediator when asked to fix UI only
+- Audit report names **Paging list correctness** when keys are missing
+
+## References
+
+- Prior art decision: `docs/animation-skill-notes.md` (Paging listed as strongest next candidate)
+- Upstream requests: [`android/skills#11`](https://github.com/android/skills/issues/11), [`android/skills#25`](https://github.com/android/skills/issues/25)
+- Official: [Paging 3 with Compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)

--- a/docs/paging-skill-plan.md
+++ b/docs/paging-skill-plan.md
@@ -13,7 +13,7 @@ When a screen uses `PagingData` / `LazyPagingItems`, agents today have no dedica
 - `items(lazyPagingItems.itemCount)` without stable `key`
 - ignoring `LoadState` (blank screens, infinite spinners, silent errors)
 - treating `LazyPagingItems` like an in-memory `List`
-- refresh canRefresh()` / `refresh()` wired from composition instead of user events
+- `refresh()` wired from composition instead of user events
 - keys from list index or `hashCode()` on paginated, merge-prone streams
 
 These are the same failure modes as lazy-list bugs, but with paging-specific triggers (append load, refresh, placeholder gaps, duplicate IDs across pages).
@@ -42,7 +42,7 @@ These are the same failure modes as lazy-list bugs, but with paging-specific tri
 
 - [x] `search-playbook.md` — Paging surface map + paging-list heuristic
 - [x] `scoring.md` — paging-specific deductions under existing categories
-- [x] `report-template.md` — **Paging list signals** (Performance) + **Paging state signals** (State)
+- [x] `report-template.md` — **Paging list signals** (Performance) + **Paging load-state signals** (State)
 - [x] `SKILL.md` — category focus bullets mention paging where relevant
 - [x] `canonical-sources.md` — Paging 3 Compose official URLs
 

--- a/docs/paging-skill-plan.md
+++ b/docs/paging-skill-plan.md
@@ -1,6 +1,7 @@
 # Paging reference — implementation plan
 
-Status: **in progress (4.2.0 branch)**  
+Status: **implemented on branch `feat/paging-reference-4.2.0` — Composer 2.5 refinement pass applied.**
+
 Last updated: 2026-06-17.
 
 This document is the plan for extending Compose Skill Suite with Paging 3 in Compose coverage. It follows the same product thesis as `animation.md` and `navigation.md`: **guardrails for LLM mistakes**, not an API encyclopedia.
@@ -82,6 +83,18 @@ Revisit only if user demand or audit false-negative rate justifies it.
 | Spinner never dismissed (refresh stuck) | State management | **Paging load-state handling** |
 | `refresh()` / `retry()` from composition | Side effects | (existing side-effect language) |
 | Exposing raw `LazyPagingItems` from design-system API | Composable API quality | (existing API-shape language) |
+
+## Composer 2.5 refinement (post-initial PR)
+
+Applied to `paging.md` before multi-LLM convergence testing:
+
+- Decision table moved to top (routing-first, like `animation.md`)
+- Single **golden path** (`FeedScreen` + `FeedList`) replacing fragmented sections
+- **Hard nos** section: `itemSnapshotList`, filter-in-composition
+- **`@Preview`** pattern with `PagingData.from(...)`
+- Note that direct `items(lazyPagingItems)` is **deprecated** — use `itemKey` + standard `items(count, key, …)`
+- Compacted: pull-to-refresh merged into LoadState; API-shape section folded into checklist
+- Cross-refs moved to footer
 
 ## Validation plan (post-merge)
 

--- a/docs/release-notes-4.2.0.md
+++ b/docs/release-notes-4.2.0.md
@@ -1,6 +1,6 @@
 # Compose Skill Suite 4.2.0 Release Notes
 
-Released: 2026-06-17 (draft — convergence testing pending)
+Status: release candidate — 2026-06-17 (convergence testing pending before GA tag)
 
 Compose Skill Suite 4.2.0 adds **Paging 3 in Compose** as a first-class review and audit surface for AI coding agents — using the same thesis as animation 4.0: **LLM tells and guardrails**, not an API encyclopedia.
 
@@ -35,7 +35,7 @@ The new paging reference targets predictable LLM mistakes:
 
 ## Planning Doc
 
-See [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md) for scope decisions, audit signal mapping, and the multi-agent validation plan.
+See [`docs/paging-skill-plan.md`](./paging-skill-plan.md) for scope decisions, audit signal mapping, and the multi-agent validation plan.
 
 ## Upgrade
 

--- a/docs/release-notes-4.2.0.md
+++ b/docs/release-notes-4.2.0.md
@@ -8,7 +8,7 @@ Compose Skill Suite 4.2.0 adds **Paging 3 in Compose** as a first-class review a
 
 ### `compose-agent` 4.2.0
 
-- Added `skills/compose-agent/references/paging.md`.
+- Added `skills/compose-agent/references/paging.md` — decision table, golden-path screen recipe, stable `itemKey`, `LoadState` branches, hard nos (`itemSnapshotList`, filter-in-composition), preview pattern. Targets LLM mistakes, not `PagingSource` implementation.
 - Added review step #14 for paging screens (`LazyPagingItems`, `collectAsLazyPagingItems`, `LoadState`, stable keys, user-driven refresh/retry).
 - Added core instruction and authoring-mode guardrail for paged feeds.
 - Cross-linked `performance.md` → `paging.md`.

--- a/docs/release-notes-4.2.0.md
+++ b/docs/release-notes-4.2.0.md
@@ -1,0 +1,52 @@
+# Compose Skill Suite 4.2.0 Release Notes
+
+Released: 2026-06-17 (draft — convergence testing pending)
+
+Compose Skill Suite 4.2.0 adds **Paging 3 in Compose** as a first-class review and audit surface for AI coding agents — using the same thesis as animation 4.0: **LLM tells and guardrails**, not an API encyclopedia.
+
+## What Changed
+
+### `compose-agent` 4.2.0
+
+- Added `skills/compose-agent/references/paging.md`.
+- Added review step #14 for paging screens (`LazyPagingItems`, `collectAsLazyPagingItems`, `LoadState`, stable keys, user-driven refresh/retry).
+- Added core instruction and authoring-mode guardrail for paged feeds.
+- Cross-linked `performance.md` → `paging.md`.
+- Added `paging` discovery keyword to Claude and Cursor manifests.
+
+The new paging reference targets predictable LLM mistakes:
+
+- Using Paging for a bounded in-memory `List` already in a `StateFlow`.
+- `items(count = …)` without stable `itemKey` (index keys on paginated feeds).
+- Ignoring `LoadState` (blank screens, infinite spinners, silent errors).
+- Treating `LazyPagingItems` like a materialized list via `itemSnapshotList`.
+- Calling `refresh()` / `retry()` from composition instead of user actions.
+
+**Out of scope:** `PagingSource` / `RemoteMediator` implementation guides.
+
+### `jetpack-compose-audit` 4.2.0
+
+- Keeps the existing four scored categories.
+- Does **not** add a separate Paging score. Paging defects map to Performance, State, or Side Effects by root cause.
+- Adds **Paging list signals** to the Performance report template (**Paging list correctness**).
+- Adds **Paging load-state signals** to the State Management report template (**Paging load-state handling**).
+- Extends `search-playbook.md` with a paging-list heuristic.
+- Extends `scoring.md` and `canonical-sources.md` with paging-specific rules and official URLs.
+
+## Planning Doc
+
+See [`docs/paging-skill-plan.md`](./docs/paging-skill-plan.md) for scope decisions, audit signal mapping, and the multi-agent validation plan.
+
+## Upgrade
+
+Both skills ship as `4.2.0`. Reinstall or refresh the plugin from this branch / release tag.
+
+Scoped review entry:
+
+```text
+compose-agent focus on paging
+```
+
+## Next: Convergence Testing
+
+Before tagging GA, run the validation plan in `docs/paging-skill-plan.md` across Claude, Codex, Cursor, and any other harness you use. Tune `paging.md` and audit heuristics from disagreements in a follow-up patch if needed.

--- a/skills/compose-agent/.claude-plugin/plugin.json
+++ b/skills/compose-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compose-agent",
-  "version": "4.1.2",
-  "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, performance-aware modifiers, Navigation 3, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin. Targets the mistakes LLMs actually make in Compose code.",
+  "version": "4.2.0",
+  "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, performance-aware modifiers, Navigation 3, Paging 3 in Compose, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin. Targets the mistakes LLMs actually make in Compose code.",
   "author": {
     "name": "Ivan Morgillo"
   },
@@ -14,6 +14,7 @@
     "coroutines",
     "navigation-3",
     "animation",
+    "paging",
     "ui-testing",
     "focus",
     "kotlin-multiplatform",

--- a/skills/compose-agent/.cursor-plugin/plugin.json
+++ b/skills/compose-agent/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compose-agent",
-  "version": "4.1.2",
-  "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, performance-aware modifiers, Navigation 3, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin. Targets the mistakes LLMs actually make in Compose code.",
+  "version": "4.2.0",
+  "description": "Agent skill that helps AI coding assistants write modern Jetpack Compose: correct state, effects, performance-aware modifiers, Navigation 3, Paging 3 in Compose, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, Android launch resources, and idiomatic Kotlin. Targets the mistakes LLMs actually make in Compose code.",
   "author": {
     "name": "Ivan Morgillo"
   },
@@ -14,6 +14,7 @@
     "coroutines",
     "navigation-3",
     "animation",
+    "paging",
     "ui-testing",
     "focus",
     "kotlin-multiplatform",

--- a/skills/compose-agent/SKILL.md
+++ b/skills/compose-agent/SKILL.md
@@ -37,7 +37,7 @@ If the repo pins older versions, match the repo — but call out what the modern
 11. Review **focus and keyboard / D-pad navigation** using `references/focus.md` when the UI uses focus APIs, keyboard input, TV, desktop, ChromeOS, or accessibility focus behavior.
 12. Review **Compose Multiplatform / KMP boundaries** using `references/kmp.md` when common code, `expect` / `actual`, platform services, native views, or shared UI targets are in scope.
 13. Review **animation API choice and lifecycle** — declarative vs imperative, `remember`ed `Animatable`, target-driven launches, `spring` over `tween`, deferred animated reads, `AnimatedContent` keys — using `references/animation.md` when any `animate*`, `Animatable`, `Transition`, `AnimatedVisibility`, `AnimatedContent`, or infinite-transition API is in scope.
-14. Review **Paging 3 in Compose** — `collectAsLazyPagingItems`, stable `itemKey`, `LoadState` branches, lifecycle-safe collection, user-driven `refresh()` / `retry()` — using `references/paging.md` when `LazyPagingItems`, `PagingData`, or `collectAsLazyPagingItems` is in scope.
+14. Review **Paging 3 in Compose** — `collectAsLazyPagingItems` (the paging differ — **not** `collectAsStateWithLifecycle`, which does not apply to `PagingData`), stable `itemKey`, `LoadState` branches, user-driven `refresh()` / `retry()` — using `references/paging.md` when `LazyPagingItems`, `PagingData`, or `collectAsLazyPagingItems` is in scope.
 15. Final **Kotlin style** pass using `references/kotlin.md`.
 
 If doing a partial review, load only the relevant reference files — each references file is designed to be read in isolation.

--- a/skills/compose-agent/SKILL.md
+++ b/skills/compose-agent/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: compose-agent
-description: "Helps AI coding assistants write modern Jetpack Compose: correct state, side effects, performance-aware modifiers, Navigation 3, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, idiomatic Kotlin, and well-shaped composable APIs. Targets the mistakes LLMs actually make in Compose code. Use when reading, writing, or reviewing Compose projects."
+description: "Helps AI coding assistants write modern Jetpack Compose: correct state, side effects, performance-aware modifiers, Navigation 3, Paging 3 in Compose, coroutines on lifecycle, animations, UI tests, focus/keyboard navigation, Compose Multiplatform boundaries, idiomatic Kotlin, and well-shaped composable APIs. Targets the mistakes LLMs actually make in Compose code. Use when reading, writing, or reviewing Compose projects."
 license: MIT
 allowed-tools: Read, Glob, Grep, Edit, Write, Bash
-argument-hint: "[focus area, e.g. 'state', 'effects', 'navigation', 'lifecycle', 'animation', 'testing', 'focus', 'kmp']"
+argument-hint: "[focus area, e.g. 'state', 'effects', 'navigation', 'paging', 'lifecycle', 'animation', 'testing', 'focus', 'kmp']"
 metadata:
   author: Ivan Morgillo
-  version: "4.1.2"
+  version: "4.2.0"
 ---
 
 # Compose Agent
@@ -37,7 +37,8 @@ If the repo pins older versions, match the repo — but call out what the modern
 11. Review **focus and keyboard / D-pad navigation** using `references/focus.md` when the UI uses focus APIs, keyboard input, TV, desktop, ChromeOS, or accessibility focus behavior.
 12. Review **Compose Multiplatform / KMP boundaries** using `references/kmp.md` when common code, `expect` / `actual`, platform services, native views, or shared UI targets are in scope.
 13. Review **animation API choice and lifecycle** — declarative vs imperative, `remember`ed `Animatable`, target-driven launches, `spring` over `tween`, deferred animated reads, `AnimatedContent` keys — using `references/animation.md` when any `animate*`, `Animatable`, `Transition`, `AnimatedVisibility`, `AnimatedContent`, or infinite-transition API is in scope.
-14. Final **Kotlin style** pass using `references/kotlin.md`.
+14. Review **Paging 3 in Compose** — `collectAsLazyPagingItems`, stable `itemKey`, `LoadState` branches, lifecycle-safe collection, user-driven `refresh()` / `retry()` — using `references/paging.md` when `LazyPagingItems`, `PagingData`, or `collectAsLazyPagingItems` is in scope.
+15. Final **Kotlin style** pass using `references/kotlin.md`.
 
 If doing a partial review, load only the relevant reference files — each references file is designed to be read in isolation.
 
@@ -54,6 +55,7 @@ If doing a partial review, load only the relevant reference files — each refer
 - Do not introduce third-party libraries without asking first. The Accompanist libraries covering pager, swipe-refresh, flow layout, and system UI controller are **deprecated** — the functionality is in AndroidX now (`HorizontalPager`, `PullToRefreshBox`, `FlowRow`/`FlowColumn`, `enableEdgeToEdge()`).
 - When an element's background reads from `MaterialTheme.colorScheme.*` (directly or via a blend), its text and icon colors must read from the same theming source. Hard-coded `Color.Black` / `Color.White` / raw ARGB literals over theme-driven backgrounds are dark-mode regressions. See `references/component-api.md`.
 - Animate declaratively first. Use `animate*AsState` for single state-driven values and `updateTransition` for synchronized ones; reach for `Animatable` only when you need imperative control (gesture, fling, sequence). Always `remember` an `Animatable`, launch target-driven animations from `LaunchedEffect` (never `scope.launch` in composition to react to state), prefer `spring()` over `tween` for interruptible motion, and read animated values in the layout/draw phase (lambda modifiers / `graphicsLayer`) so the animation does not recompose every frame. See `references/animation.md`.
+- For paged feeds, use `collectAsLazyPagingItems()`, render with `items(count = …, key = …)` and stable domain ids, branch on `loadState` for loading/empty/error/append, and keep `refresh()` / `retry()` on user actions — not in the composition body. See `references/paging.md`.
 
 ## Output Format (review mode)
 
@@ -139,6 +141,7 @@ When the agent is **writing new code** rather than reviewing, the same rules app
 - If it collects a Flow, is it `collectAsStateWithLifecycle()`?
 - Is the parameter order: data → modifier → other → content slot last?
 - If it animates, is the API declarative first, remembered where needed, lifecycle-aware, and phase-correct?
+- If it pages, are keys stable, `LoadState` handled, and refresh/retry user-driven?
 - If it needs focus, testing, or platform-specific behavior, did you load the focused reference before judging?
 
 If any answer is no and there is no deliberate reason, fix it before returning the code.
@@ -169,6 +172,7 @@ If the user needs any of the above, narrow the scope and say so.
 - `references/focus.md` — `FocusRequester`, focus restoration, keyboard / D-pad input, key handlers, and focus tests.
 - `references/kmp.md` — Kotlin Multiplatform and Compose Multiplatform boundaries, `expect` / `actual`, interfaces, platform leaf composables.
 - `references/animation.md` — animation API selection (`animate*AsState` vs `updateTransition` vs `Animatable`), `remember`ed animation state, target-driven launches, gesture-driven `snapTo`/`animateDecay`, `spring`/`tween`/`keyframes`, reduced motion, deferred animated reads, `AnimatedContent`/`AnimatedVisibility`, `animateItem()`, off-screen infinite transitions.
+- `references/paging.md` — Paging 3 in Compose: when to page vs plain lists, `collectAsLazyPagingItems`, stable `itemKey`, `LoadState` UI, pull-to-refresh, anti-patterns for paginated lazy lists.
 - `references/kotlin.md` — Kotlin coding conventions and Android Kotlin style the LLM keeps missing.
 
 ## Primary Sources

--- a/skills/compose-agent/SKILL.md
+++ b/skills/compose-agent/SKILL.md
@@ -48,7 +48,7 @@ If doing a partial review, load only the relevant reference files — each refer
 - Every composable that takes a `Modifier` names the parameter `modifier`, types it `Modifier = Modifier`, and applies it **to the outermost layout only**. Never create a `modifier` parameter you do not forward.
 - Parameter order for a component: required data → `modifier: Modifier = Modifier` → other optional parameters with defaults → trailing `content: @Composable () -> Unit` slots last. One `modifier` parameter per component.
 - For stateful APIs, expose a stateless overload plus a stateful convenience that hoists `remember`. See `references/component-api.md`.
-- Collect Flows with `collectAsStateWithLifecycle()` in UI code. Plain `collectAsState()` keeps collecting when the screen is not visible and burns battery and bandwidth.
+- Collect Flows with `collectAsStateWithLifecycle()` in UI code. Plain `collectAsState()` keeps collecting when the screen is not visible and burns battery and bandwidth. **Exception:** `Flow<PagingData<T>>` is collected with `collectAsLazyPagingItems()`, never `collectAsStateWithLifecycle()` — see `references/paging.md`.
 - Prefer `rememberSaveable` over `remember` for UI state that should survive configuration change or process death, unless the value is unserializable or derivable.
 - Use the typed state factories (`mutableIntStateOf`, `mutableLongStateOf`, `mutableFloatStateOf`, `mutableDoubleStateOf`) for primitive state. Raw `mutableStateOf<Int>(...)` boxes.
 - Never put a lambda in a `CompositionLocal`. Use explicit parameters.
@@ -138,7 +138,7 @@ When the agent is **writing new code** rather than reviewing, the same rules app
 - Is state hoisted, or is there a clear reason to own it here?
 - If it renders a list, does it use a stable `key =`?
 - If it launches work, is that work in a `LaunchedEffect`, `produceState`, or the ViewModel — not in the composition body?
-- If it collects a Flow, is it `collectAsStateWithLifecycle()`?
+- If it collects a Flow, is it `collectAsStateWithLifecycle()`? (A `Flow<PagingData<T>>` is the exception — it uses `collectAsLazyPagingItems()`.)
 - Is the parameter order: data → modifier → other → content slot last?
 - If it animates, is the API declarative first, remembered where needed, lifecycle-aware, and phase-correct?
 - If it pages, are keys stable, `LoadState` handled, and refresh/retry user-driven?

--- a/skills/compose-agent/references/concurrency.md
+++ b/skills/compose-agent/references/concurrency.md
@@ -4,7 +4,7 @@ The Coroutines / Flow model is Android's first-class async primitive. Compose si
 
 ## Collecting Flows In UI
 
-**Always use `collectAsStateWithLifecycle()`** for Flows that drive UI.
+**Always use `collectAsStateWithLifecycle()`** for Flows that drive UI — **except `Flow<PagingData<T>>`**, which is collected with `collectAsLazyPagingItems()` and must not be routed through `collectAsStateWithLifecycle()`. See `paging.md`.
 
 ```kotlin
 // Wrong

--- a/skills/compose-agent/references/effects.md
+++ b/skills/compose-agent/references/effects.md
@@ -259,6 +259,7 @@ For value-based animations (`animate*AsState`), no effect is needed at all — t
 - **State mutation in a `@Composable` function body outside `remember`/`mutableStateOf`.** The read–write cycle causes invalidation storms ("backwards writes").
 - **Using `LaunchedEffect` where `collectAsStateWithLifecycle` suffices.** If the goal is "show this flow as state", do not open the flow manually.
 - **Nesting effects.** A `LaunchedEffect` inside another `LaunchedEffect` is almost always a sign the outer effect should have had different keys.
+- **Calling `LazyPagingItems.refresh()` / `retry()` from composition or `LaunchedEffect(Unit)`** to "load on enter." Initial load is `PagingData`'s job; these are user-initiated only. See `paging.md`.
 
 ## Primary Sources
 

--- a/skills/compose-agent/references/flows.md
+++ b/skills/compose-agent/references/flows.md
@@ -36,7 +36,7 @@ fun FeedScreen(viewModel: FeedViewModel) {
 
 **Two questions, separate answers:**
 
-- **Where do you collect?** A screen-boundary `collectAsStateWithLifecycle()` (or a keyed `LaunchedEffect(flow) { flow.collect { ... } }` for events) is fine. Collection happens at the UI edge.
+- **Where do you collect?** A screen-boundary `collectAsStateWithLifecycle()` (or a keyed `LaunchedEffect(flow) { flow.collect { ... } }` for events) is fine. Collection happens at the UI edge. **Exception:** a `Flow<PagingData<T>>` is collected with `collectAsLazyPagingItems()`, never `collectAsStateWithLifecycle()` — see `paging.md`.
 - **Where do you shape?** Operators (`combine`, `flatMapLatest`, `stateIn`, `debounce`, `retry`, etc.) belong in a presenter / state holder / ViewModel — **not** in a composable. The data layer hands the UI a single coherent stream.
 
 **LLM tells:**

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -15,7 +15,8 @@ For a numeric audit of an existing codebase, use the sibling `jetpack-compose-au
 | Feed that grows as the user scrolls (network / DB window) | `Flow<PagingData<T>>` + `collectAsLazyPagingItems()` |
 | List already complete in `StateFlow<List<T>>` | `LazyColumn` + `items(list)` — **do not add Paging** |
 | First paint while refresh runs | branch on `loadState.refresh is LoadState.Loading && itemCount == 0` |
-| Error on first load | `loadState.refresh is LoadState.Error` + `retry()` |
+| Error on first load (nothing on screen yet) | `loadState.refresh is LoadState.Error && itemCount == 0` + `retry()` |
+| Refresh error with content already shown | transient message (snackbar) + keep the list — **do not** replace the feed with a full-screen error |
 | Empty feed after successful load | `loadState.refresh is LoadState.NotLoading && itemCount == 0` |
 | Footer "loading more" | `loadState.append is LoadState.Loading` |
 | Footer error | `loadState.append is LoadState.Error` + retry affordance |
@@ -40,13 +41,23 @@ fun FeedScreen(viewModel: FeedViewModel) {
         lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
             LoadingContent()
         }
-        lazyPagingItems.loadState.refresh is LoadState.Error -> {
+        // Full-screen error ONLY when there is nothing to show. A refresh that
+        // fails while a feed is already on screen must NOT blow the list away.
+        lazyPagingItems.loadState.refresh is LoadState.Error && lazyPagingItems.itemCount == 0 -> {
             ErrorContent(onRetry = { lazyPagingItems.retry() })
         }
         lazyPagingItems.loadState.refresh is LoadState.NotLoading && lazyPagingItems.itemCount == 0 -> {
             EmptyContent()
         }
         else -> {
+            // itemCount > 0: keep the list. A failed pull-to-refresh surfaces as a
+            // transient message, not a full-screen replacement.
+            val refreshState = lazyPagingItems.loadState.refresh
+            LaunchedEffect(refreshState) {
+                if (refreshState is LoadState.Error) {
+                    // snackbarHostState.showSnackbar(...) with a Retry action -> lazyPagingItems.retry()
+                }
+            }
             PullToRefreshBox(
                 isRefreshing = lazyPagingItems.loadState.refresh is LoadState.Loading,
                 onRefresh = { lazyPagingItems.refresh() },
@@ -82,7 +93,7 @@ ViewModel guardrail: expose `Flow<PagingData<Post>>` built once and **`cachedIn(
 
 **LLM tell:** `viewModel.feed.collectAsState()` then manually iterating — there is no supported `PagingData` → `List` shortcut for infinite feeds.
 
-**LLM tell:** `viewModel.feed.collectAsStateWithLifecycle()` on a `Flow<PagingData<T>>`. The lifecycle rule that holds for every other screen does **not** transfer here — `collectAsLazyPagingItems()` is the only supported collector, and it is already lifecycle-aware. Treat "this Flow needs `collectAsStateWithLifecycle`" as not applying to `PagingData`.
+**LLM tell:** `viewModel.feed.collectAsStateWithLifecycle()` on a `Flow<PagingData<T>>`. The lifecycle rule that holds for every other screen does **not** transfer here. `PagingData` is a one-shot stream consumed by a dedicated differ — there is no supported path to collect it through `collectAsStateWithLifecycle`; `collectAsLazyPagingItems()` is the collector that drives the differ. (Note it is not "lifecycle-aware" in the `repeatOnLifecycle` sense — it collects for as long as it is in composition; backgrounding does not pause it. That is expected for paging and not something to "fix" by reaching for `collectAsStateWithLifecycle`.) Treat "this Flow needs `collectAsStateWithLifecycle`" as not applying to `PagingData`.
 
 <https://developer.android.com/topic/libraries/architecture/paging/v3-compose#collect-lazyPagingItems>
 
@@ -109,6 +120,7 @@ Rules:
 - Never use **`hashCode()`** on a non-`data class` or on objects that can collide across pages.
 - Duplicate backend IDs (merged feeds, reconnect storms) → dedupe in the repository or synthesize keys (`"${source}-${id}"`). Compose crashes with `Key ... was already used` otherwise.
 - No **`indexOf` / `indexOfFirst`** inside the item factory — same O(n²) and crash profile as non-paging lazy lists. See `performance.md`.
+- For **heterogeneous** paged feeds (ads, headers, mixed row types), pass **`contentType = lazyPagingItems.itemContentType { … }`** alongside `itemKey`. Without it Compose cannot reuse slots across differently-shaped items and recomposition cost climbs — the same rule as `contentType` on a plain lazy list.
 
 <https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems#itemKey(kotlin.Function1)>
 
@@ -119,18 +131,23 @@ Rules:
 | Signal | Typical UI |
 |--------|------------|
 | `refresh is Loading` && `itemCount == 0` | Full-screen loading |
-| `refresh is Error` | Error + `retry()` |
+| `refresh is Error` && `itemCount == 0` | Full-screen error + `retry()` |
+| `refresh is Error` && `itemCount > 0` | Transient message (snackbar) — keep the list |
 | `refresh is NotLoading` && `itemCount == 0` | Empty state |
 | `append is Loading` | Footer spinner / row placeholder |
 | `append is Error` | Snackbar or inline retry on footer |
 
 **LLM tell:** rendering `LazyColumn` with zero items and no loading/error branch — users see a blank screen while refresh runs or after a failed fetch.
 
+**LLM tell:** a bare `refresh is LoadState.Error -> ErrorContent()` branch with **no `itemCount` guard** — a transient pull-to-refresh failure then wipes an already-loaded feed and replaces it with a full-screen error. Gate the full-screen error on `itemCount == 0`; surface refresh errors that arrive with content already on screen as a snackbar/inline retry instead.
+
 **LLM tell:** calling **`refresh()`** unconditionally in `LaunchedEffect(Unit)` or in the composable body to "load data on enter." Initial load is **`PagingData`'s job**; `refresh()` is for **user-initiated** reload. One-shot navigation args belong in the ViewModel / `Pager` factory, not a composition-time refresh loop.
 
 **LLM tell:** a parallel `mutableStateOf(isLoading)` shadowing `loadState` — two sources of truth for the same UX. Prefer `loadState` unless the design genuinely decouples them.
 
 Use **`retry()`** after `LoadState.Error`. Wire **`refresh()`** to pull-to-refresh or explicit reload actions only.
+
+**`prepend`** usually needs no UI of its own (bidirectional feeds are rare); when it does, mirror the `append` pattern — a header spinner on `prepend is Loading`, a header retry on `prepend is Error`. Do not invent a separate loading flag for it.
 
 <https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems>
 

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -1,6 +1,6 @@
 # Paging
 
-Paging 3 in Compose is not "a lazy list that loads more." It is a **windowed, append-only stream** with load states, refresh semantics, and key rules of its own. LLMs treat `LazyPagingItems` like `List<Item>` and reproduce the same three production bugs:
+Paging 3 in Compose is not "a lazy list that loads more." It is a **windowed paged stream** (primarily append, with prepend and refresh generations) carrying load states, refresh semantics, and key rules of its own. LLMs treat `LazyPagingItems` like `List<Item>` and reproduce the same three production bugs:
 
 1. **Missing or index-only keys** on a paginated stream
 2. **Ignored `LoadState`** — blank screens, stuck spinners, silent errors
@@ -99,7 +99,7 @@ ViewModel guardrail: expose `Flow<PagingData<Post>>` built once and **`cachedIn(
 
 ## Keys — Stable Domain Identity, Not Index
 
-The supported integration is **`items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey { … })`**. The older `items(lazyPagingItems)` overload on `LazyListScope` is **deprecated** — use `itemKey` with the standard lazy `items(count, key, …)` API instead (works for `LazyColumn`, `LazyVerticalGrid`, `HorizontalPager`, etc.).
+The supported integration is **`items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey { … })`**. The older `items(lazyPagingItems)` overload on `LazyListScope` is **deprecated** — use `itemKey` with the standard lazy `items(count, key, …)` API instead (`LazyColumn`, `LazyVerticalGrid`, and friends). For a `HorizontalPager`/`VerticalPager` driven by `LazyPagingItems`, the wiring differs — pass `pageCount = { lazyPagingItems.itemCount }` and read with `lazyPagingItems[page]`, supplying a stable `key` — so don't assume the `items(count, key)` shape transfers verbatim.
 
 ```kotlin
 // LLM-generated — index keys break on prepend / refresh / reorder
@@ -147,7 +147,7 @@ Rules:
 
 Use **`retry()`** after `LoadState.Error`. Wire **`refresh()`** to pull-to-refresh or explicit reload actions only.
 
-**DB-backed / `RemoteMediator` feeds:** `loadState.refresh` reflects the *mediator* state, so it can flip to `NotLoading` before the cached page is actually emitted — a brief blank flash. When the feed is backed by a local cache (Room), branch on **`loadState.source.refresh`** for the local-load signal (and `loadState.mediator?.refresh` for the network one) instead of the combined `loadState.refresh`. This reference is UI guidance, not a `RemoteMediator` cookbook — just know which signal to read.
+**DB-backed / `RemoteMediator` feeds:** keep branching on the **combined `loadState.refresh`** for normal screen loading — it already defers to the mediator and only reports `NotLoading` once **both** `source` and `mediator` have settled, so it will not blank the screen early. Reach for `loadState.source.refresh` / `loadState.mediator?.refresh` **only** when you deliberately render cached content while a network refresh continues in the background (explicit cache-vs-network UI). Branching on `source.refresh` for the default load is a tell — it shows an empty state while the mediator is still fetching. This reference is UI guidance, not a `RemoteMediator` cookbook.
 
 **`prepend`** usually needs no UI of its own (bidirectional feeds are rare); when it does, mirror the `append` pattern — a header spinner on `prepend is Loading`, a header retry on `prepend is Error`. Do not invent a separate loading flag for it.
 

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -69,8 +69,10 @@ private fun FeedList(lazyPagingItems: LazyPagingItems<Post>) {
                 else -> PostRow(post)
             }
         }
-        if (lazyPagingItems.loadState.append is LoadState.Loading) {
-            item { AppendSpinner() }
+        when (lazyPagingItems.loadState.append) {
+            is LoadState.Loading -> item { AppendSpinner() }
+            is LoadState.Error -> item { AppendRetryRow(onRetry = { lazyPagingItems.retry() }) }
+            else -> Unit
         }
     }
 }
@@ -79,6 +81,8 @@ private fun FeedList(lazyPagingItems: LazyPagingItems<Post>) {
 ViewModel guardrail: expose `Flow<PagingData<Post>>` built once and **`cachedIn(viewModelScope)`**. Do not rebuild `Pager` / `PagingData` on UI recomposition.
 
 **LLM tell:** `viewModel.feed.collectAsState()` then manually iterating — there is no supported `PagingData` → `List` shortcut for infinite feeds.
+
+**LLM tell:** `viewModel.feed.collectAsStateWithLifecycle()` on a `Flow<PagingData<T>>`. The lifecycle rule that holds for every other screen does **not** transfer here — `collectAsLazyPagingItems()` is the only supported collector, and it is already lifecycle-aware. Treat "this Flow needs `collectAsStateWithLifecycle`" as not applying to `PagingData`.
 
 <https://developer.android.com/topic/libraries/architecture/paging/v3-compose#collect-lazyPagingItems>
 
@@ -144,7 +148,9 @@ val filtered = remember(query) {
 
 Filtering, sorting, and search belong in the **ViewModel / PagingSource / `flatMapLatest` on the `Flow<PagingData<T>>`**, not in the composable. Materializing defeats the lazy window and reintroduces memory churn.
 
-**Do not skip placeholders.** When `lazyPagingItems[index]` is `null`, render a placeholder — do not assume every slot is non-null.
+**Do not skip placeholders.** When `lazyPagingItems[index]` is `null`, render a placeholder — do not assume every slot is non-null. Never `!!` the slot: it NPE-crashes the first time a page is still loading.
+
+Whether `null` slots occur at all is set by **`PagingConfig.enablePlaceholders`** (a repository/`Pager` decision, not a UI one). Placeholders **on** → `get(index)` can return `null` and you **must** handle it. Placeholders **off** → slots are never `null`, but the list jumps as pages arrive. Match the UI branch to the config: don't write a placeholder branch that can never run, and don't assume non-null when placeholders are enabled.
 
 ## Preview
 

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -53,7 +53,9 @@ fun FeedScreen(viewModel: FeedViewModel) {
             // itemCount > 0: keep the list. A failed pull-to-refresh surfaces as a
             // transient message, not a full-screen replacement.
             val refreshState = lazyPagingItems.loadState.refresh
-            LaunchedEffect(refreshState) {
+            // Key on the Error itself (or a flag), not the whole loadState, so the
+            // snackbar fires once per failure and does not re-show on unrelated state churn.
+            LaunchedEffect(refreshState is LoadState.Error) {
                 if (refreshState is LoadState.Error) {
                     // snackbarHostState.showSnackbar(...) with a Retry action -> lazyPagingItems.retry()
                 }

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -1,0 +1,158 @@
+# Paging
+
+Paging 3 in Compose is not "a lazy list that loads more." It is a **windowed, append-only stream** with its own load states, refresh semantics, and key stability rules. LLMs treat `LazyPagingItems` like `List<Item>` and reproduce the same three production bugs: **missing keys**, **ignored `LoadState`**, and **refresh wired from composition**.
+
+Paging defects are usually lazy-list defects wearing a paginator costume. Cross-reference `performance.md` (keys, scroll cost), `state.md` (single source of truth for load UI), `concurrency.md` (lifecycle collection), and `effects.md` (when refresh belongs in an effect vs a click handler).
+
+For a numeric audit of an existing codebase, use the sibling `jetpack-compose-audit` skill — paging smells score under Performance and State, not a separate category.
+
+## When Paging vs a Normal List
+
+| Situation | Use |
+|-----------|-----|
+| Bounded, in-memory collection (settings rows, tabs, static menu) | `LazyColumn` + `items(list)` |
+| Network/DB-backed stream that grows as the user scrolls | `Pager` → `PagingData` → `collectAsLazyPagingItems()` |
+| User expects pull-to-refresh over a paged feed | Paging + explicit refresh UI driven by `LoadState` |
+| Small list loaded once from the ViewModel (`StateFlow<List<T>>`) | Plain list — do not add Paging ceremony |
+
+**LLM tell:** introducing `Pager`, `PagingSource`, and `LazyPagingItems` for a screen that already holds a complete `List` in a `StateFlow`. Paging earns its complexity only when the dataset is **too large or too slow** to hold entirely in memory.
+
+<https://developer.android.com/topic/libraries/architecture/paging/v3-compose>
+
+## Collect Once, Lifecycle-Aware
+
+`LazyPagingItems` comes from collecting a `Flow<PagingData<T>>`. In UI:
+
+```kotlin
+@Composable
+fun FeedScreen(viewModel: FeedViewModel) {
+    val lazyPagingItems = viewModel.feed.collectAsLazyPagingItems()
+    FeedList(lazyPagingItems)
+}
+```
+
+Guardrails:
+
+- **`PagingData` is collected in the ViewModel** with `cachedIn(viewModelScope)` (or equivalent scope). Do not rebuild `Pager`/`PagingData` on every UI recomposition.
+- Prefer **`collectAsLazyPagingItems()`** in the composable that renders the list. It is the supported Compose integration API.
+- If the surrounding screen already uses lifecycle-aware Flow collection elsewhere, stay consistent — do not mix `collectAsState()` for paging with `collectAsStateWithLifecycle()` for other streams on the same screen without a reason.
+
+**LLM tell:** `viewModel.feed.collectAsState()` then manually iterating — there is no supported `PagingData` → `List` shortcut for infinite feeds.
+
+<https://developer.android.com/topic/libraries/architecture/paging/v3-compose#collect-lazyPagingItems>
+
+## Render With `itemCount` and Stable Keys
+
+The supported lazy integration uses **`items(count = lazyPagingItems.itemCount, key = …)`** (or the equivalent `items` overload that accepts `LazyPagingItems`). Keys must come from **stable domain identity**, not list index.
+
+```kotlin
+// LLM-generated — index keys break on prepend/refresh/reorder
+LazyColumn {
+    items(count = lazyPagingItems.itemCount, key = { index -> index }) { index ->
+        val item = lazyPagingItems[index]
+        if (item != null) FeedRow(item)
+    }
+}
+
+// Correct — stable id; null slot = placeholder while page loads
+LazyColumn {
+    items(
+        count = lazyPagingItems.itemCount,
+        key = lazyPagingItems.itemKey { it.id },
+    ) { index ->
+        lazyPagingItems[index]?.let { FeedRow(it) }
+    }
+}
+```
+
+Rules:
+
+- Use **`itemKey { it.<stableId> }`** when the item type is non-null in the lambda.
+- Never use **`hashCode()`** on a non-`data class` or on objects that can collide across pages.
+- If the backend can return **duplicate IDs** (merged feeds, reconnect storms), dedupe in the repository layer or synthesize keys (`"${source}-${id}"`) — Compose will crash with `Key ... was already used` otherwise.
+- Do not call **`indexOf` / `indexOfFirst`** inside the item factory to recover identity — same O(n²) and crash profile as non-paging lazy lists. See `performance.md`.
+
+**LLM tell:** `lazyPagingItems.itemSnapshotList.items.forEach { … }` or building a `List` from the snapshot and passing it to a child `LazyColumn`. Stay in the **`items(count = …)`** integration; the snapshot is for debugging/tests, not primary UI wiring.
+
+<https://developer.android.com/topic/libraries/architecture/paging/v3-compose#display-lazylist>
+
+## LoadState — Loading, Empty, Error, Append
+
+`LazyPagingItems` exposes **`loadState`** (refresh / prepend / append). UI must branch on it — do not assume `itemCount > 0` means success.
+
+| Signal | Typical UI |
+|--------|------------|
+| `loadState.refresh is LoadState.Loading` && `itemCount == 0` | Full-screen loading |
+| `loadState.refresh is LoadState.Error` | Error + retry (`lazyPagingItems.retry()`) |
+| `loadState.append is LoadState.Loading` | Footer spinner / item placeholder |
+| `loadState.append is LoadState.Error` | Snackbar or inline "tap to retry" on footer |
+| `loadState.refresh is LoadState.NotLoading` && `itemCount == 0` | Empty state |
+
+```kotlin
+when {
+    lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
+        LoadingContent()
+    }
+    lazyPagingItems.loadState.refresh is LoadState.Error -> {
+        ErrorContent(onRetry = { lazyPagingItems.retry() })
+    }
+    else -> {
+        FeedList(lazyPagingItems)
+    }
+}
+```
+
+**LLM tell:** rendering `LazyColumn` with zero items and no loading/error branch — users see a blank screen while refresh runs or after a failed fetch.
+
+**LLM tell:** calling **`refresh()`** unconditionally in a `LaunchedEffect(Unit)` or in the composable body to "load data on enter." Initial load is **`PagingData`'s job**; `refresh()` is for **user-initiated** pull-to-refresh or explicit reload actions. One-shot navigation args belong in the ViewModel/`Pager` factory, not a composition-time refresh loop.
+
+<https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems>
+
+## Pull-to-Refresh and Retry
+
+Wire refresh to **user events** or explicit reload actions:
+
+```kotlin
+PullToRefreshBox(
+    isRefreshing = lazyPagingItems.loadState.refresh is LoadState.Loading,
+    onRefresh = { lazyPagingItems.refresh() },
+) {
+    FeedList(lazyPagingItems)
+}
+```
+
+Use **`retry()`** for error recovery after `LoadState.Error`. Do not spin a separate `mutableStateOf(isLoading)` that duplicates `loadState` unless the design needs decoupled UX — two sources of truth for loading is an LLM favorite and a bug farm.
+
+## API Shape for Reusable Components
+
+Shared list components should take **`LazyPagingItems<T>`** (or a narrow interface) plus callbacks — not a materialized `List<T>` that defeats paging.
+
+For design-system wrappers:
+
+- Accept `modifier: Modifier = Modifier` on the outermost scroll container.
+- Do not expose **`MutableState`** for load state when `loadState` already exists on `LazyPagingItems`.
+- Keep **`refresh` / `retry`** as callback parameters if the parent owns the `LazyPagingItems` instance.
+
+See `component-api.md` for parameter order and slot conventions.
+
+## Anti-Pattern Checklist
+
+Before returning paging UI code, verify:
+
+- [ ] Paging is justified (unbounded / paged data source), not a `StateFlow<List>` in disguise
+- [ ] `PagingData` is **`cachedIn`** appropriate scope in the ViewModel
+- [ ] List uses **`items(count = lazyPagingItems.itemCount, key = …)`** with **stable ids**
+- [ ] No **index-only** or **`hashCode()`** keys on merge-prone feeds
+- [ ] **`LoadState`** drives initial loading, empty, error, and append footer — not a parallel manual flag
+- [ ] **`refresh()` / `retry()`** are user-driven or explicitly documented — not fired from composition on every recomposition
+- [ ] No **`indexOf`** identity recovery inside item factories
+- [ ] Placeholder slots (`lazyPagingItems[i] == null`) handled without crashing
+
+## Primary Sources
+
+- <https://developer.android.com/topic/libraries/architecture/paging/v3-compose>
+- <https://developer.android.com/topic/libraries/architecture/paging/v3-overview>
+- <https://developer.android.com/reference/kotlin/androidx/paging/compose/package-summary>
+- <https://developer.android.com/develop/ui/compose/lists> — lazy list keys (applies to paging items)
+
+When supplemental blog posts disagree with these, the Android Developers pages win.

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -147,6 +147,8 @@ Rules:
 
 Use **`retry()`** after `LoadState.Error`. Wire **`refresh()`** to pull-to-refresh or explicit reload actions only.
 
+**DB-backed / `RemoteMediator` feeds:** `loadState.refresh` reflects the *mediator* state, so it can flip to `NotLoading` before the cached page is actually emitted — a brief blank flash. When the feed is backed by a local cache (Room), branch on **`loadState.source.refresh`** for the local-load signal (and `loadState.mediator?.refresh` for the network one) instead of the combined `loadState.refresh`. This reference is UI guidance, not a `RemoteMediator` cookbook — just know which signal to read.
+
 **`prepend`** usually needs no UI of its own (bidirectional feeds are rare); when it does, mirror the `append` pattern — a header spinner on `prepend is Loading`, a header retry on `prepend is Error`. Do not invent a separate loading flag for it.
 
 <https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems>
@@ -200,7 +202,7 @@ Before returning paging UI code, verify:
 
 - `performance.md` — lazy keys, scroll cost, duplicate-key crashes
 - `state.md` — single source of truth for load UI
-- `concurrency.md` — lifecycle-aware collection on the same screen
+- `concurrency.md` — lifecycle-aware collection of **other** (non-`PagingData`) flows on the same screen; it does not apply to `LazyPagingItems`
 - `effects.md` — refresh belongs in event handlers, not composition body
 
 ## Primary Sources

--- a/skills/compose-agent/references/paging.md
+++ b/skills/compose-agent/references/paging.md
@@ -1,152 +1,184 @@
 # Paging
 
-Paging 3 in Compose is not "a lazy list that loads more." It is a **windowed, append-only stream** with its own load states, refresh semantics, and key stability rules. LLMs treat `LazyPagingItems` like `List<Item>` and reproduce the same three production bugs: **missing keys**, **ignored `LoadState`**, and **refresh wired from composition**.
+Paging 3 in Compose is not "a lazy list that loads more." It is a **windowed, append-only stream** with load states, refresh semantics, and key rules of its own. LLMs treat `LazyPagingItems` like `List<Item>` and reproduce the same three production bugs:
 
-Paging defects are usually lazy-list defects wearing a paginator costume. Cross-reference `performance.md` (keys, scroll cost), `state.md` (single source of truth for load UI), `concurrency.md` (lifecycle collection), and `effects.md` (when refresh belongs in an effect vs a click handler).
+1. **Missing or index-only keys** on a paginated stream
+2. **Ignored `LoadState`** — blank screens, stuck spinners, silent errors
+3. **`refresh()` wired from composition** instead of user actions
 
 For a numeric audit of an existing codebase, use the sibling `jetpack-compose-audit` skill — paging smells score under Performance and State, not a separate category.
 
-## When Paging vs a Normal List
+## Decision Table
 
-| Situation | Use |
-|-----------|-----|
-| Bounded, in-memory collection (settings rows, tabs, static menu) | `LazyColumn` + `items(list)` |
-| Network/DB-backed stream that grows as the user scrolls | `Pager` → `PagingData` → `collectAsLazyPagingItems()` |
-| User expects pull-to-refresh over a paged feed | Paging + explicit refresh UI driven by `LoadState` |
-| Small list loaded once from the ViewModel (`StateFlow<List<T>>`) | Plain list — do not add Paging ceremony |
+| You are doing… | Use |
+|---|---|
+| Feed that grows as the user scrolls (network / DB window) | `Flow<PagingData<T>>` + `collectAsLazyPagingItems()` |
+| List already complete in `StateFlow<List<T>>` | `LazyColumn` + `items(list)` — **do not add Paging** |
+| First paint while refresh runs | branch on `loadState.refresh is LoadState.Loading && itemCount == 0` |
+| Error on first load | `loadState.refresh is LoadState.Error` + `retry()` |
+| Empty feed after successful load | `loadState.refresh is LoadState.NotLoading && itemCount == 0` |
+| Footer "loading more" | `loadState.append is LoadState.Loading` |
+| Footer error | `loadState.append is LoadState.Error` + retry affordance |
+| User pull-to-refresh / explicit reload | `refresh()` on gesture — **not** in composition |
+| Stable lazy identity | `items(count = …, key = lazyPagingItems.itemKey { it.id })` |
+| `@Preview` of a paged screen | `flowOf(PagingData.from(samples)).collectAsLazyPagingItems()` |
 
 **LLM tell:** introducing `Pager`, `PagingSource`, and `LazyPagingItems` for a screen that already holds a complete `List` in a `StateFlow`. Paging earns its complexity only when the dataset is **too large or too slow** to hold entirely in memory.
 
 <https://developer.android.com/topic/libraries/architecture/paging/v3-compose>
 
-## Collect Once, Lifecycle-Aware
+## Golden Path
 
-`LazyPagingItems` comes from collecting a `Flow<PagingData<T>>`. In UI:
+One screen-level recipe. Copy this shape; swap names.
 
 ```kotlin
 @Composable
 fun FeedScreen(viewModel: FeedViewModel) {
     val lazyPagingItems = viewModel.feed.collectAsLazyPagingItems()
-    FeedList(lazyPagingItems)
+
+    when {
+        lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
+            LoadingContent()
+        }
+        lazyPagingItems.loadState.refresh is LoadState.Error -> {
+            ErrorContent(onRetry = { lazyPagingItems.retry() })
+        }
+        lazyPagingItems.loadState.refresh is LoadState.NotLoading && lazyPagingItems.itemCount == 0 -> {
+            EmptyContent()
+        }
+        else -> {
+            PullToRefreshBox(
+                isRefreshing = lazyPagingItems.loadState.refresh is LoadState.Loading,
+                onRefresh = { lazyPagingItems.refresh() },
+            ) {
+                FeedList(lazyPagingItems)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeedList(lazyPagingItems: LazyPagingItems<Post>) {
+    LazyColumn {
+        items(
+            count = lazyPagingItems.itemCount,
+            key = lazyPagingItems.itemKey { it.id },
+        ) { index ->
+            when (val post = lazyPagingItems[index]) {
+                null -> PostPlaceholder()
+                else -> PostRow(post)
+            }
+        }
+        if (lazyPagingItems.loadState.append is LoadState.Loading) {
+            item { AppendSpinner() }
+        }
+    }
 }
 ```
 
-Guardrails:
-
-- **`PagingData` is collected in the ViewModel** with `cachedIn(viewModelScope)` (or equivalent scope). Do not rebuild `Pager`/`PagingData` on every UI recomposition.
-- Prefer **`collectAsLazyPagingItems()`** in the composable that renders the list. It is the supported Compose integration API.
-- If the surrounding screen already uses lifecycle-aware Flow collection elsewhere, stay consistent — do not mix `collectAsState()` for paging with `collectAsStateWithLifecycle()` for other streams on the same screen without a reason.
+ViewModel guardrail: expose `Flow<PagingData<Post>>` built once and **`cachedIn(viewModelScope)`**. Do not rebuild `Pager` / `PagingData` on UI recomposition.
 
 **LLM tell:** `viewModel.feed.collectAsState()` then manually iterating — there is no supported `PagingData` → `List` shortcut for infinite feeds.
 
 <https://developer.android.com/topic/libraries/architecture/paging/v3-compose#collect-lazyPagingItems>
 
-## Render With `itemCount` and Stable Keys
+## Keys — Stable Domain Identity, Not Index
 
-The supported lazy integration uses **`items(count = lazyPagingItems.itemCount, key = …)`** (or the equivalent `items` overload that accepts `LazyPagingItems`). Keys must come from **stable domain identity**, not list index.
+The supported integration is **`items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey { … })`**. The older `items(lazyPagingItems)` overload on `LazyListScope` is **deprecated** — use `itemKey` with the standard lazy `items(count, key, …)` API instead (works for `LazyColumn`, `LazyVerticalGrid`, `HorizontalPager`, etc.).
 
 ```kotlin
-// LLM-generated — index keys break on prepend/refresh/reorder
-LazyColumn {
-    items(count = lazyPagingItems.itemCount, key = { index -> index }) { index ->
-        val item = lazyPagingItems[index]
-        if (item != null) FeedRow(item)
-    }
-}
+// LLM-generated — index keys break on prepend / refresh / reorder
+items(count = lazyPagingItems.itemCount, key = { index -> index }) { index -> … }
 
-// Correct — stable id; null slot = placeholder while page loads
-LazyColumn {
-    items(
-        count = lazyPagingItems.itemCount,
-        key = lazyPagingItems.itemKey { it.id },
-    ) { index ->
-        lazyPagingItems[index]?.let { FeedRow(it) }
-    }
+// Correct — stable id; null slot = placeholder while a page loads
+items(
+    count = lazyPagingItems.itemCount,
+    key = lazyPagingItems.itemKey { it.id },
+) { index ->
+    lazyPagingItems[index]?.let { PostRow(it) } ?: PostPlaceholder()
 }
 ```
 
 Rules:
 
-- Use **`itemKey { it.<stableId> }`** when the item type is non-null in the lambda.
+- Keys come from **stable domain ids**, never bare index on paginated feeds.
 - Never use **`hashCode()`** on a non-`data class` or on objects that can collide across pages.
-- If the backend can return **duplicate IDs** (merged feeds, reconnect storms), dedupe in the repository layer or synthesize keys (`"${source}-${id}"`) — Compose will crash with `Key ... was already used` otherwise.
-- Do not call **`indexOf` / `indexOfFirst`** inside the item factory to recover identity — same O(n²) and crash profile as non-paging lazy lists. See `performance.md`.
+- Duplicate backend IDs (merged feeds, reconnect storms) → dedupe in the repository or synthesize keys (`"${source}-${id}"`). Compose crashes with `Key ... was already used` otherwise.
+- No **`indexOf` / `indexOfFirst`** inside the item factory — same O(n²) and crash profile as non-paging lazy lists. See `performance.md`.
 
-**LLM tell:** `lazyPagingItems.itemSnapshotList.items.forEach { … }` or building a `List` from the snapshot and passing it to a child `LazyColumn`. Stay in the **`items(count = …)`** integration; the snapshot is for debugging/tests, not primary UI wiring.
+<https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems#itemKey(kotlin.Function1)>
 
-<https://developer.android.com/topic/libraries/architecture/paging/v3-compose#display-lazylist>
+## LoadState and Refresh
 
-## LoadState — Loading, Empty, Error, Append
-
-`LazyPagingItems` exposes **`loadState`** (refresh / prepend / append). UI must branch on it — do not assume `itemCount > 0` means success.
+`LazyPagingItems.loadState` has **refresh**, **prepend**, and **append**. UI must branch — do not assume `itemCount > 0` means success.
 
 | Signal | Typical UI |
 |--------|------------|
-| `loadState.refresh is LoadState.Loading` && `itemCount == 0` | Full-screen loading |
-| `loadState.refresh is LoadState.Error` | Error + retry (`lazyPagingItems.retry()`) |
-| `loadState.append is LoadState.Loading` | Footer spinner / item placeholder |
-| `loadState.append is LoadState.Error` | Snackbar or inline "tap to retry" on footer |
-| `loadState.refresh is LoadState.NotLoading` && `itemCount == 0` | Empty state |
-
-```kotlin
-when {
-    lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
-        LoadingContent()
-    }
-    lazyPagingItems.loadState.refresh is LoadState.Error -> {
-        ErrorContent(onRetry = { lazyPagingItems.retry() })
-    }
-    else -> {
-        FeedList(lazyPagingItems)
-    }
-}
-```
+| `refresh is Loading` && `itemCount == 0` | Full-screen loading |
+| `refresh is Error` | Error + `retry()` |
+| `refresh is NotLoading` && `itemCount == 0` | Empty state |
+| `append is Loading` | Footer spinner / row placeholder |
+| `append is Error` | Snackbar or inline retry on footer |
 
 **LLM tell:** rendering `LazyColumn` with zero items and no loading/error branch — users see a blank screen while refresh runs or after a failed fetch.
 
-**LLM tell:** calling **`refresh()`** unconditionally in a `LaunchedEffect(Unit)` or in the composable body to "load data on enter." Initial load is **`PagingData`'s job**; `refresh()` is for **user-initiated** pull-to-refresh or explicit reload actions. One-shot navigation args belong in the ViewModel/`Pager` factory, not a composition-time refresh loop.
+**LLM tell:** calling **`refresh()`** unconditionally in `LaunchedEffect(Unit)` or in the composable body to "load data on enter." Initial load is **`PagingData`'s job**; `refresh()` is for **user-initiated** reload. One-shot navigation args belong in the ViewModel / `Pager` factory, not a composition-time refresh loop.
+
+**LLM tell:** a parallel `mutableStateOf(isLoading)` shadowing `loadState` — two sources of truth for the same UX. Prefer `loadState` unless the design genuinely decouples them.
+
+Use **`retry()`** after `LoadState.Error`. Wire **`refresh()`** to pull-to-refresh or explicit reload actions only.
 
 <https://developer.android.com/reference/kotlin/androidx/paging/compose/LazyPagingItems>
 
-## Pull-to-Refresh and Retry
+## Hard Nos
 
-Wire refresh to **user events** or explicit reload actions:
+**Do not materialize the window in composition.**
 
 ```kotlin
-PullToRefreshBox(
-    isRefreshing = lazyPagingItems.loadState.refresh is LoadState.Loading,
-    onRefresh = { lazyPagingItems.refresh() },
-) {
+// LLM tell — snapshot is for debug/tests, not primary UI
+lazyPagingItems.itemSnapshotList.items.forEach { … }
+val filtered = remember(query) {
+    lazyPagingItems.itemSnapshotList.filter { it.title.contains(query) }
+}
+```
+
+Filtering, sorting, and search belong in the **ViewModel / PagingSource / `flatMapLatest` on the `Flow<PagingData<T>>`**, not in the composable. Materializing defeats the lazy window and reintroduces memory churn.
+
+**Do not skip placeholders.** When `lazyPagingItems[index]` is `null`, render a placeholder — do not assume every slot is non-null.
+
+## Preview
+
+```kotlin
+@Preview
+@Composable
+private fun FeedListPreview() {
+    val lazyPagingItems = flowOf(PagingData.from(samplePosts)).collectAsLazyPagingItems()
     FeedList(lazyPagingItems)
 }
 ```
 
-Use **`retry()`** for error recovery after `LoadState.Error`. Do not spin a separate `mutableStateOf(isLoading)` that duplicates `loadState` unless the design needs decoupled UX — two sources of truth for loading is an LLM favorite and a bug farm.
-
-## API Shape for Reusable Components
-
-Shared list components should take **`LazyPagingItems<T>`** (or a narrow interface) plus callbacks — not a materialized `List<T>` that defeats paging.
-
-For design-system wrappers:
-
-- Accept `modifier: Modifier = Modifier` on the outermost scroll container.
-- Do not expose **`MutableState`** for load state when `loadState` already exists on `LazyPagingItems`.
-- Keep **`refresh` / `retry`** as callback parameters if the parent owns the `LazyPagingItems` instance.
-
-See `component-api.md` for parameter order and slot conventions.
+**LLM tell:** faking a paged screen with `List<Post>` passed to a non-paging `LazyColumn` — previews drift from production wiring. Use `PagingData.from(...)` for Compose previews.
 
 ## Anti-Pattern Checklist
 
 Before returning paging UI code, verify:
 
-- [ ] Paging is justified (unbounded / paged data source), not a `StateFlow<List>` in disguise
-- [ ] `PagingData` is **`cachedIn`** appropriate scope in the ViewModel
-- [ ] List uses **`items(count = lazyPagingItems.itemCount, key = …)`** with **stable ids**
-- [ ] No **index-only** or **`hashCode()`** keys on merge-prone feeds
-- [ ] **`LoadState`** drives initial loading, empty, error, and append footer — not a parallel manual flag
-- [ ] **`refresh()` / `retry()`** are user-driven or explicitly documented — not fired from composition on every recomposition
+- [ ] Paging is justified — not a `StateFlow<List>` in disguise
+- [ ] `PagingData` is **`cachedIn`** in the ViewModel
+- [ ] **`items(count, key = itemKey { stableId })`** — no index-only keys on paginated feeds
+- [ ] **`LoadState`** drives loading / empty / error / append — no duplicate manual loading flag
+- [ ] **`refresh()` / `retry()`** are user-driven — not fired from composition each recomposition
+- [ ] No **`itemSnapshotList`** primary UI path; no filter/sort in the composable
 - [ ] No **`indexOf`** identity recovery inside item factories
-- [ ] Placeholder slots (`lazyPagingItems[i] == null`) handled without crashing
+- [ ] **`null` slots** render placeholders
+- [ ] Reusable list APIs take **`LazyPagingItems<T>`** (or callbacks from the owner) — not a materialized `List<T>`; see `component-api.md` for `modifier` and parameter order
+
+## Cross-References
+
+- `performance.md` — lazy keys, scroll cost, duplicate-key crashes
+- `state.md` — single source of truth for load UI
+- `concurrency.md` — lifecycle-aware collection on the same screen
+- `effects.md` — refresh belongs in event handlers, not composition body
 
 ## Primary Sources
 

--- a/skills/compose-agent/references/performance.md
+++ b/skills/compose-agent/references/performance.md
@@ -138,6 +138,8 @@ Safe in composition: simple field reads (`.size`, `.length`, `.isEmpty()`, index
 
 See `references/animation.md` for API choice, `updateTransition`, `AnimatedContent`, lazy-list item animation, infinite transitions, gesture-driven `Animatable`, and reduced motion.
 
+See `references/paging.md` for Paging 3 lazy-list keys, `LoadState`, and paginated-stream crash patterns that reuse lazy-list rules with paging-specific triggers.
+
 Core performance rules:
 
 - Target-driven: `LaunchedEffect(target) { animatable.animateTo(target) }`, or better, `animate*AsState` / `updateTransition` with no effect at all. Event-driven animations launched from click or gesture handlers can use `rememberCoroutineScope()`.

--- a/skills/compose-agent/references/state.md
+++ b/skills/compose-agent/references/state.md
@@ -2,6 +2,8 @@
 
 Compose state rules LLMs routinely get wrong. Most mistakes come from one of three places: state placed at the wrong altitude, `remember` without the right key, or treating `State<T>` like a value instead of an observable.
 
+For paged feeds (`Flow<PagingData<T>>`), the collection and load-state rules live in `paging.md` — that stream is the one exception that is **not** collected with `collectAsStateWithLifecycle()`.
+
 ## State Hoisting — Where State Lives
 
 Default shape for a screen:

--- a/skills/jetpack-compose-audit/.claude-plugin/plugin.json
+++ b/skills/jetpack-compose-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jetpack-compose-audit",
-  "version": "4.1.2",
-  "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score, per-category 0-10 scores, a COMPOSE-AUDIT-REPORT.md with every deduction cited against developer.android.com, and coverage notes for animation performance, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
+  "version": "4.2.0",
+  "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score, per-category 0-10 scores, a COMPOSE-AUDIT-REPORT.md with every deduction cited against developer.android.com, and coverage notes for animation performance, paging list correctness, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
   "author": {
     "name": "Ivan Morgillo"
   },
@@ -13,6 +13,7 @@
     "audit",
     "performance",
     "animation",
+    "paging",
     "compose-compiler",
     "strong-skipping",
     "stability",

--- a/skills/jetpack-compose-audit/.cursor-plugin/plugin.json
+++ b/skills/jetpack-compose-audit/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jetpack-compose-audit",
-  "version": "4.1.2",
-  "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score, per-category 0-10 scores, a COMPOSE-AUDIT-REPORT.md with every deduction cited against developer.android.com, and coverage notes for animation performance, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
+  "version": "4.2.0",
+  "description": "Strict, evidence-based audit for Android Jetpack Compose repositories. Produces a 0-100 score, per-category 0-10 scores, a COMPOSE-AUDIT-REPORT.md with every deduction cited against developer.android.com, and coverage notes for animation performance, paging list correctness, UI tests, focus/keyboard, Compose Multiplatform, and Android launch UX surfaces.",
   "author": {
     "name": "Ivan Morgillo"
   },
@@ -13,6 +13,7 @@
     "audit",
     "performance",
     "animation",
+    "paging",
     "compose-compiler",
     "strong-skipping",
     "stability",

--- a/skills/jetpack-compose-audit/SKILL.md
+++ b/skills/jetpack-compose-audit/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[repo path or module path]"
 
 This skill audits Android Jetpack Compose repositories with a strict, evidence-based report.
 
-**Skill version:** 4.1.2 — released 2026-06-14. **Compose track:** Kotlin 2.0.20+ / Compose Compiler 1.5.4+ (Strong Skipping Mode default). See the README changelog for what changed.
+**Skill version:** 4.2.0 — released 2026-06-17. **Compose track:** Kotlin 2.0.20+ / Compose Compiler 1.5.4+ (Strong Skipping Mode default). See the README changelog for what changed.
 
 It is intentionally focused on four categories:
 
@@ -201,6 +201,7 @@ Focus on:
 - expensive work in composition
 - avoidable recomposition
 - lazy list keys
+- paging list keys and `LazyPagingItems` misuse when `collectAsLazyPagingItems` is present
 - bad state-read timing
 - unstable or overly broad reads
 - backwards writes
@@ -216,6 +217,7 @@ Focus on:
 - reusable stateless seams
 - correct use of `remember` vs `rememberSaveable`
 - lifecycle-aware observable collection
+- paging `LoadState` handling (loading / empty / error / append) when `LazyPagingItems` is present
 - observable vs non-observable mutable state
 
 #### Side Effects

--- a/skills/jetpack-compose-audit/SKILL.md
+++ b/skills/jetpack-compose-audit/SKILL.md
@@ -321,7 +321,7 @@ Include:
   - one official doc URL from `references/canonical-sources.md`
   - expected impact that matches the active ceiling table: on SSM-off, frame it in terms of named-only `skippable%` / unstable-param reductions; on SSM-on, frame it in terms of removing instance-recreation churn, fixing expensive / broken `equals()`, or clearing the binding cap
 - whether a `material-3` audit is worth running next
-- whether focused follow-up is worth running next: `compose-agent focus on testing`, `compose-agent focus on focus`, `compose-agent focus on kmp`, or `compose-agent focus on animation`
+- whether focused follow-up is worth running next: `compose-agent focus on testing`, `compose-agent focus on focus`, `compose-agent focus on kmp`, `compose-agent focus on animation`, or `compose-agent focus on paging`
 
 The top-three fixes in the chat summary MUST be the same items as the report's `Prioritized Fixes` list (same file paths, same doc links). Do not add generic advice in chat that isn't in the written report.
 

--- a/skills/jetpack-compose-audit/SKILL.md
+++ b/skills/jetpack-compose-audit/SKILL.md
@@ -350,7 +350,7 @@ For medium or large repositories:
 - Do not inflate the performance score just because the app uses Compose.
 - Do not over-penalize isolated experiments or sample files unless they are part of production paths.
 - Do not score design in v1.
-- Do not flag `LaunchedEffect(Unit)` or `LaunchedEffect(true)` on its own — the "run once" pattern is idiomatic. Only flag it when the body captures a value that may change without `rememberUpdatedState`.
+- Do not flag `LaunchedEffect(Unit)` or `LaunchedEffect(true)` on its own — the "run once" pattern is idiomatic. Only flag it when the body captures a value that may change without `rememberUpdatedState`. **Paging carve-out:** `LaunchedEffect(Unit) { lazyPagingItems.refresh() }` (or `retry()`) *is* a Side Effects defect — initial paged load is `PagingData`'s job, and `refresh()`/`retry()` are user-initiated. Flag it.
 - Do not deduct on Compose Multiplatform code paths for Android-only APIs (`collectAsStateWithLifecycle`, `lifecycle-runtime-compose`). Note the platform constraint as a tradeoff instead.
 - Do not double-count the same root cause across categories. A stability problem typically surfaces in both Performance and State — pick the dominant category and cross-reference.
 

--- a/skills/jetpack-compose-audit/SKILL.md
+++ b/skills/jetpack-compose-audit/SKILL.md
@@ -231,6 +231,7 @@ Focus on:
 - cleanup correctness
 - lifecycle-aware effect behavior
 - animations driven from `LaunchedEffect(target)` for target-driven state changes (not from the composition body; `rememberCoroutineScope().launch { animateTo(...) }` is usually for event- or gesture-driven animation)
+- paging `LazyPagingItems.refresh()` / `retry()` called from composition or `LaunchedEffect(Unit)` to "load on enter" — initial load is `PagingData`'s job; these are user-initiated only
 
 #### Composable API Quality
 
@@ -314,6 +315,7 @@ Include:
 - one-line judgment for each category, with the applied ceiling if any (e.g. "Performance 8/10 — capped by the SSM-on table: recreated `FeedItemUiModel` params")
 - when animation defects affected Performance, name them explicitly in the Performance line (e.g. "Performance 6/10 — animated `offset` reads recompose `DrawerContent` every frame")
 - when animation defects affected Side Effects, name them explicitly in the Side Effects line (e.g. "Side Effects 5/10 — `scope.launch { animateTo(...) }` in composition on `SettingsScreen`")
+- when paging defects affected Side Effects, name them explicitly in the Side Effects line (e.g. "Side Effects 6/10 — `LaunchedEffect(Unit) { feed.refresh() }` on `FeedScreen` loads from composition")
 - compiler-report highlights when Step 4 succeeded: Strong Skipping on/off (or mixed across modules), which ceiling table was applied, module-wide `skippable%`, named-only `skippable%`, which metric actually bound the cap, count of unstable shared types, and any module that failed to build
 - **top three actionable fixes**, each with:
   - the concrete change ("add `key = { it.id }` to `items(...)` in `feed/FeedList.kt:42`")

--- a/skills/jetpack-compose-audit/evals/evals.json
+++ b/skills/jetpack-compose-audit/evals/evals.json
@@ -142,6 +142,7 @@
       "files": [],
       "expectations": [
         "Flag `items.refresh()` in `LaunchedEffect(Unit)`: initial load is `PagingData`'s job; `refresh()` is for user-initiated reload.",
+        "Classify the composition-time `refresh()` under Side Effects (paging side-effect signal), not Performance or State.",
         "Flag the `refresh is LoadState.Error` branch with no `itemCount` guard — a transient failure replaces an already-loaded feed with a full-screen error.",
         "Recommend gating full-screen error on `itemCount == 0` and surfacing refresh errors that arrive with content as a snackbar / inline retry.",
         "Credit the correct stable `itemKey` already present instead of re-flagging it."

--- a/skills/jetpack-compose-audit/evals/evals.json
+++ b/skills/jetpack-compose-audit/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "jetpack-compose-audit",
-  "description": "Acceptance evals for the API-hygiene, effect-correctness, cancellation, and state-boundary behavior introduced in 4.1.x. These are the audit/review acceptance criteria the skill must preserve; they also back compose-agent review behavior. Run a model against each prompt and check it satisfies every expectation.",
+  "description": "Acceptance evals for the API-hygiene, effect-correctness, cancellation, and state-boundary behavior introduced in 4.1.x, plus Paging 3 in Compose list/load-state behavior added in 4.2.0 (cases 10-11). These are the audit/review acceptance criteria the skill must preserve; they also back compose-agent review behavior. Run a model against each prompt and check it satisfies every expectation.",
   "evals": [
     {
       "id": 0,
@@ -131,12 +131,13 @@
         "Flag `items(items.itemCount)` without a stable `itemKey` on a paginated feed as index-keying.",
         "Recommend `key = items.itemKey { it.id }` from stable domain ids, not bare index or `hashCode()`.",
         "Flag the missing `LoadState` handling: zero items with no loading/empty/error branch is a blank-screen tell.",
+        "Note the null-slot branch (`items[index]?.let { … }` with no placeholder) should match `PagingConfig.enablePlaceholders`.",
         "Map findings to existing Performance (paging list correctness) and State (paging load-state) categories, not a separate paging score."
       ]
     },
     {
       "id": 11,
-      "prompt": "Audit this paged screen's load handling:\n@Composable fun FeedScreen(viewModel: FeedViewModel) {\n    val items = viewModel.feed.collectAsLazyPagingItems()\n    LaunchedEffect(Unit) { items.refresh() }\n    if (items.loadState.refresh is LoadState.Error) FullScreenError(onRetry = { items.refresh() })\n    LazyColumn { items(items.itemCount, key = items.itemKey { it.id }) { i -> items[i]?.let { PostRow(it) } } }\n}",
+      "prompt": "Audit this paged screen's load handling:\n@Composable fun FeedScreen(viewModel: FeedViewModel) {\n    val items = viewModel.feed.collectAsLazyPagingItems()\n    LaunchedEffect(Unit) { items.refresh() }\n    if (items.loadState.refresh is LoadState.Error) FullScreenError(onRetry = { items.retry() })\n    LazyColumn { items(items.itemCount, key = items.itemKey { it.id }) { i -> items[i]?.let { PostRow(it) } } }\n}",
       "expected_output": "An audit flagging the composition-time `refresh()` in `LaunchedEffect(Unit)` and the unguarded full-screen error branch that wipes already-loaded content on a transient refresh failure, recommending user-driven refresh and gating the full-screen error on `itemCount == 0`.",
       "files": [],
       "expectations": [

--- a/skills/jetpack-compose-audit/evals/evals.json
+++ b/skills/jetpack-compose-audit/evals/evals.json
@@ -121,6 +121,30 @@
         "Discuss calling the same content slot from multiple branches as a lifecycle/state-preservation risk.",
         "Recommend a layout shape that preserves slot lifecycle, or `movableContentOf` with a freshness strategy when moving content is intentional."
       ]
+    },
+    {
+      "id": 10,
+      "prompt": "Audit this paged feed:\n@Composable fun FeedScreen(viewModel: FeedViewModel) {\n    val items = viewModel.feed.collectAsLazyPagingItems()\n    LazyColumn {\n        items(items.itemCount) { index ->\n            items[index]?.let { PostRow(it) }\n        }\n    }\n}",
+      "expected_output": "An audit flagging the index-keyed paged list (no stable `itemKey`) and the absence of any `LoadState` branch, recommending `itemKey { it.id }` and refresh/empty/error/append handling, scoped under Performance (list correctness) and State (load-state handling) rather than as a new paging score.",
+      "files": [],
+      "expectations": [
+        "Flag `items(items.itemCount)` without a stable `itemKey` on a paginated feed as index-keying.",
+        "Recommend `key = items.itemKey { it.id }` from stable domain ids, not bare index or `hashCode()`.",
+        "Flag the missing `LoadState` handling: zero items with no loading/empty/error branch is a blank-screen tell.",
+        "Map findings to existing Performance (paging list correctness) and State (paging load-state) categories, not a separate paging score."
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Audit this paged screen's load handling:\n@Composable fun FeedScreen(viewModel: FeedViewModel) {\n    val items = viewModel.feed.collectAsLazyPagingItems()\n    LaunchedEffect(Unit) { items.refresh() }\n    if (items.loadState.refresh is LoadState.Error) FullScreenError(onRetry = { items.refresh() })\n    LazyColumn { items(items.itemCount, key = items.itemKey { it.id }) { i -> items[i]?.let { PostRow(it) } } }\n}",
+      "expected_output": "An audit flagging the composition-time `refresh()` in `LaunchedEffect(Unit)` and the unguarded full-screen error branch that wipes already-loaded content on a transient refresh failure, recommending user-driven refresh and gating the full-screen error on `itemCount == 0`.",
+      "files": [],
+      "expectations": [
+        "Flag `items.refresh()` in `LaunchedEffect(Unit)`: initial load is `PagingData`'s job; `refresh()` is for user-initiated reload.",
+        "Flag the `refresh is LoadState.Error` branch with no `itemCount` guard — a transient failure replaces an already-loaded feed with a full-screen error.",
+        "Recommend gating full-screen error on `itemCount == 0` and surfacing refresh errors that arrive with content as a snackbar / inline retry.",
+        "Credit the correct stable `itemKey` already present instead of re-flagging it."
+      ]
     }
   ]
 }

--- a/skills/jetpack-compose-audit/references/canonical-sources.md
+++ b/skills/jetpack-compose-audit/references/canonical-sources.md
@@ -56,6 +56,22 @@ These ground:
 - reusable animated components exposing `animationSpec` and `label`
 - scoping `rememberInfiniteTransition` so it stops when the host leaves composition
 
+### Paging (Compose UI)
+
+- Android Developers: `Paging 3 with Compose`
+  `https://developer.android.com/topic/libraries/architecture/paging/v3-compose`
+- Android Developers: `Paging 3 overview`
+  `https://developer.android.com/topic/libraries/architecture/paging/v3-overview`
+- Android Developers: `androidx.paging.compose` reference
+  `https://developer.android.com/reference/kotlin/androidx/paging/compose/package-summary`
+
+These ground:
+
+- `collectAsLazyPagingItems()` integration
+- stable `itemKey` on paginated lazy lists
+- `LoadState` branches for loading / empty / error / append
+- user-driven `refresh()` / `retry()` rather than composition-time reload loops
+
 ### State
 
 - Android Developers: `State and Jetpack Compose`  

--- a/skills/jetpack-compose-audit/references/report-template.md
+++ b/skills/jetpack-compose-audit/references/report-template.md
@@ -109,7 +109,7 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 **Paging load-state signals**
 
 - Status: [clean / risky / not present / not inspected]
-- If risky, state exactly which paging rule affected State: ignored `LoadState.Error`, missing empty state, stuck refresh spinner, or duplicate manual loading flag shadowing `loadState`.
+- If risky, state exactly which paging rule affected State: ignored `LoadState.Error`, missing empty state, stuck refresh spinner, duplicate manual loading flag shadowing `loadState`, append error with no `retry()` footer, or `lazyPagingItems[index]!!` / null-slot handling mismatched to `PagingConfig.enablePlaceholders`.
 - Keep missing keys / index keys on `LazyPagingItems` in Performance (**Paging list correctness**) instead.
 
 **Evidence**

--- a/skills/jetpack-compose-audit/references/report-template.md
+++ b/skills/jetpack-compose-audit/references/report-template.md
@@ -133,6 +133,11 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 - Status: [clean / risky / not present / not inspected]
 - If risky, name the Side Effects issue explicitly: `Animatable.animateTo()` from composition, `rememberCoroutineScope().launch { animateTo(...) }` reacting to state instead of `LaunchedEffect(target)`, or `Animatable` + `LaunchedEffect` where `animate*AsState` / `updateTransition` would suffice.
 
+**Paging side-effect signals**
+
+- Status: [clean / risky / not present / not inspected]
+- If risky, name the Side Effects issue explicitly: `LazyPagingItems.refresh()` / `retry()` called unconditionally from composition or `LaunchedEffect(Unit)` to "load on enter" (initial load is `PagingData`'s job; `refresh()`/`retry()` are user-initiated). Keep missing keys / `LoadState` handling in Performance / State instead.
+
 **Evidence**
 
 - `path/to/file1.kt:LL` — [brief reason] · References: <https://developer.android.com/...>

--- a/skills/jetpack-compose-audit/references/report-template.md
+++ b/skills/jetpack-compose-audit/references/report-template.md
@@ -109,7 +109,7 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 **Paging load-state signals**
 
 - Status: [clean / risky / not present / not inspected]
-- If risky, state exactly which paging rule affected State: ignored `LoadState.Error`, missing empty state, stuck refresh spinner, duplicate manual loading flag shadowing `loadState`, append error with no `retry()` footer, or `lazyPagingItems[index]!!` / null-slot handling mismatched to `PagingConfig.enablePlaceholders`.
+- If risky, state exactly which paging rule affected State: ignored `LoadState.Error`, missing empty state, stuck refresh spinner, duplicate manual loading flag shadowing `loadState`, append error with no `retry()` footer, full-screen refresh error with no `itemCount == 0` guard (wipes an already-loaded feed), or `lazyPagingItems[index]!!` / null-slot handling mismatched to `PagingConfig.enablePlaceholders`.
 - Keep missing keys / index keys on `LazyPagingItems` in Performance (**Paging list correctness**) instead.
 
 **Evidence**

--- a/skills/jetpack-compose-audit/references/report-template.md
+++ b/skills/jetpack-compose-audit/references/report-template.md
@@ -83,6 +83,13 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 - If risky, state exactly which animation rule affected Performance: composition-phase animated reads, `Animatable` not remembered, `rememberInfiniteTransition` kept alive offscreen, deprecated `animateItemPlacement()`, or missing lazy-list keys for `animateItem()`.
 - Keep animation-driving mistakes in Side Effects instead when the root cause is launching animation work from composition or using `rememberCoroutineScope().launch { animateTo(...) }` for target-driven state changes.
 
+**Paging list signals**
+
+- Status: [clean / risky / not present / not inspected]
+- If risky, state exactly which paging rule affected Performance: missing or index-only keys on `LazyPagingItems`, `itemSnapshotList` primary UI wiring, or paginated-stream duplicate-key risk.
+- Keep ignored `LoadState` / duplicate loading flags in State Management instead (**Paging load-state handling**).
+- Keep unconditional `refresh()` / `retry()` from composition in Side Effects.
+
 **Evidence**
 
 - `path/to/file1.kt:LL` — [brief reason] · References: <https://developer.android.com/...>
@@ -98,6 +105,12 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 
 - [problem 1]
 - [problem 2]
+
+**Paging load-state signals**
+
+- Status: [clean / risky / not present / not inspected]
+- If risky, state exactly which paging rule affected State: ignored `LoadState.Error`, missing empty state, stuck refresh spinner, or duplicate manual loading flag shadowing `loadState`.
+- Keep missing keys / index keys on `LazyPagingItems` in Performance (**Paging list correctness**) instead.
 
 **Evidence**
 
@@ -167,6 +180,7 @@ Use this section for concrete, user-visible problems the audit intentionally tra
 - Run `compose-agent focus on focus` if keyboard, D-pad, TV, desktop, ChromeOS, or focus-restoration behavior is present.
 - Run `compose-agent focus on kmp` if Compose Multiplatform, KMP source sets, `expect` / `actual`, or platform interop boundaries are present.
 - Run `compose-agent focus on animation` if animation findings need a file-scope rewrite rather than an audit-level diagnosis.
+- Run `compose-agent focus on paging` if paging list / load-state findings need a file-scope rewrite rather than an audit-level diagnosis.
 ```
 
 ## Tone

--- a/skills/jetpack-compose-audit/references/scoring.md
+++ b/skills/jetpack-compose-audit/references/scoring.md
@@ -121,6 +121,11 @@ Deduct for:
 
 When any of these animation rules affects the Performance score, name it in the Performance section as **Animation phase correctness** rather than folding it into a generic recomposition note. Readers should be able to see at a glance whether animation contributed to the score.
 
+- `LazyPagingItems` rendered with `items(count = …)` but **missing `key =`** or using **index-only keys** on a paginated/merged feed — reorder, refresh, and prepend can crash or thrash compositions → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose), [lists](https://developer.android.com/develop/ui/compose/lists)
+- treating `LazyPagingItems` like a materialized list (`itemSnapshotList` primary UI path, `forEach` into a nested lazy list) instead of the supported `items(count = …)` integration → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+
+When any of these paging rules affects the Performance score, name it in the Performance section as **Paging list correctness** rather than folding it into a generic lazy-list note.
+
 Suggested interpretation:
 
 - `9-10`: clean patterns are common and performance smells are rare
@@ -210,6 +215,10 @@ Deduct for:
 - `mutableStateOf` held in a `ViewModel` instead of `StateFlow` / `MutableStateFlow` — couples the ViewModel to the Compose runtime and hurts testability. App-level teams may accept this tradeoff deliberately; note the tradeoff rather than deducting heavily unless it is widespread → [architecture](https://developer.android.com/develop/ui/compose/architecture)
 - ViewModel-to-UI events modeled only as `Channel` / `SharedFlow` when the outcome must survive lifecycle gaps (snackbars, validation messages, navigation decisions). Prefer durable UI state with an acknowledgement callback for must-deliver outcomes; reserve `Channel` / `SharedFlow` for ephemeral signals with documented delivery semantics → [UI events](https://developer.android.com/topic/architecture/ui-layer/events), [architecture](https://developer.android.com/develop/ui/compose/architecture)
 - `rememberSaveable` used inside a `LazyListScope` item factory (per-item expansion state, per-item form fields) — each entry is serialized into the saved-state `Bundle` which is capped at ~1 MB; large lists trigger `TransactionTooLargeException` → [state](https://developer.android.com/develop/ui/compose/state)
+- paging UI that ignores `LazyPagingItems.loadState` — blank screen during initial refresh, stuck spinner, or silent failure with no `retry()` path → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+- duplicate manual loading flags (`mutableStateOf(isLoading)`) shadowing `loadState` on paging screens — two sources of truth for the same UX → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+
+When any of these paging rules affects the State management score, name it in the State section as **Paging load-state handling** rather than folding it into a generic state note.
 
 Suggested interpretation:
 
@@ -255,6 +264,7 @@ Deduct for:
 - `navController.navigate(...)` invoked from the composition body instead of an event handler or effect → [navigation](https://developer.android.com/develop/ui/compose/navigation)
 - `rememberCoroutineScope().launch { animatable.animateTo(target) }` where a `LaunchedEffect(target) { animatable.animateTo(target) }` would more clearly express target-driven animation — prefer `LaunchedEffect(target)` when restart semantics should follow the key automatically; keep `rememberCoroutineScope()` for event- or gesture-driven animation → [animation](https://developer.android.com/develop/ui/compose/animation/value-based), [side-effects](https://developer.android.com/develop/ui/compose/side-effects)
 - `Animatable.animateTo(...)` invoked from the composition body (not from inside an effect) — runs on every recomposition and never cancels → [animation](https://developer.android.com/develop/ui/compose/animation/value-based), [side-effects](https://developer.android.com/develop/ui/compose/side-effects)
+- unconditional `lazyPagingItems.refresh()` / `retry()` from the composable body or bare `LaunchedEffect(Unit)` without a documented one-shot reason — initial load belongs to `PagingData`; refresh is user-driven → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose), [side-effects](https://developer.android.com/develop/ui/compose/side-effects)
 
 Suggested interpretation:
 

--- a/skills/jetpack-compose-audit/references/scoring.md
+++ b/skills/jetpack-compose-audit/references/scoring.md
@@ -269,6 +269,8 @@ Deduct for:
 - `Animatable.animateTo(...)` invoked from the composition body (not from inside an effect) — runs on every recomposition and never cancels → [animation](https://developer.android.com/develop/ui/compose/animation/value-based), [side-effects](https://developer.android.com/develop/ui/compose/side-effects)
 - unconditional `lazyPagingItems.refresh()` / `retry()` from the composable body or bare `LaunchedEffect(Unit)` without a documented one-shot reason — initial load belongs to `PagingData`; refresh is user-driven → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose), [side-effects](https://developer.android.com/develop/ui/compose/side-effects)
 
+When this paging rule affects the Side Effects score, name it in the Side Effects section as **Paging side-effect signals** rather than folding it into a generic effect note — mirroring **Paging list correctness** (Performance) and **Paging load-state handling** (State).
+
 Suggested interpretation:
 
 - `9-10`: deliberate, lifecycle-aware effect usage

--- a/skills/jetpack-compose-audit/references/scoring.md
+++ b/skills/jetpack-compose-audit/references/scoring.md
@@ -217,6 +217,8 @@ Deduct for:
 - `rememberSaveable` used inside a `LazyListScope` item factory (per-item expansion state, per-item form fields) — each entry is serialized into the saved-state `Bundle` which is capped at ~1 MB; large lists trigger `TransactionTooLargeException` → [state](https://developer.android.com/develop/ui/compose/state)
 - paging UI that ignores `LazyPagingItems.loadState` — blank screen during initial refresh, stuck spinner, or silent failure with no `retry()` path → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
 - duplicate manual loading flags (`mutableStateOf(isLoading)`) shadowing `loadState` on paging screens — two sources of truth for the same UX → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+- `loadState.append is LoadState.Error` handled only as a spinner or not at all — append failures leave the user with no way to resume the feed; an append-error footer must offer `retry()` → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+- `lazyPagingItems[index]!!` (or assuming every slot is non-null) — with `PagingConfig.enablePlaceholders = true`, slots are `null` while a page loads and `!!` NPE-crashes; the dual smell is a placeholder branch that can never run because placeholders are disabled → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
 
 When any of these paging rules affects the State management score, name it in the State section as **Paging load-state handling** rather than folding it into a generic state note.
 

--- a/skills/jetpack-compose-audit/references/scoring.md
+++ b/skills/jetpack-compose-audit/references/scoring.md
@@ -219,6 +219,7 @@ Deduct for:
 - duplicate manual loading flags (`mutableStateOf(isLoading)`) shadowing `loadState` on paging screens — two sources of truth for the same UX → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
 - `loadState.append is LoadState.Error` handled only as a spinner or not at all — append failures leave the user with no way to resume the feed; an append-error footer must offer `retry()` → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
 - `lazyPagingItems[index]!!` (or assuming every slot is non-null) — with `PagingConfig.enablePlaceholders = true`, slots are `null` while a page loads and `!!` NPE-crashes; the dual smell is a placeholder branch that can never run because placeholders are disabled → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
+- `loadState.refresh is LoadState.Error -> FullScreenError()` with **no `itemCount == 0` guard** — a transient pull-to-refresh failure then wipes an already-loaded feed and replaces it with a full-screen error. Full-screen error should gate on `itemCount == 0`; refresh errors arriving with content on screen belong in a snackbar / inline retry → [paging compose](https://developer.android.com/topic/libraries/architecture/paging/v3-compose)
 
 When any of these paging rules affects the State management score, name it in the State section as **Paging load-state handling** rather than folding it into a generic state note.
 

--- a/skills/jetpack-compose-audit/references/search-playbook.md
+++ b/skills/jetpack-compose-audit/references/search-playbook.md
@@ -215,6 +215,7 @@ When `collectAsLazyPagingItems` / `LazyPagingItems` is present, paging-specific 
    - **`refresh()`** / **`retry()`** are not invoked unconditionally from the composable body or a bare `LaunchedEffect(Unit)` without a documented one-shot reason
    - no **`indexOf` / `indexOfFirst`** inside the paging item factory
    - the append branch handles **`LoadState.Error`** with a `retry()` footer, not only `LoadState.Loading`
+   - a full-screen `refresh is LoadState.Error` branch is **guarded by `itemCount == 0`** — otherwise a transient pull-to-refresh failure wipes an already-loaded feed
    - no **`lazyPagingItems[index]!!`** — null slots occur when `PagingConfig.enablePlaceholders = true`; check the null handling matches the config
 3. When keys are missing or index-based on a paginated feed, flag under Performance as **Paging list correctness** and recommend `compose-agent focus on paging`.
 4. When `LoadState.Error` is ignored or loading never resolves, flag under State management as **Paging load-state handling**.

--- a/skills/jetpack-compose-audit/references/search-playbook.md
+++ b/skills/jetpack-compose-audit/references/search-playbook.md
@@ -214,6 +214,8 @@ When `collectAsLazyPagingItems` / `LazyPagingItems` is present, paging-specific 
    - UI branches on **`loadState`** (refresh / append / error) — not a blank list during initial load or after failure
    - **`refresh()`** / **`retry()`** are not invoked unconditionally from the composable body or a bare `LaunchedEffect(Unit)` without a documented one-shot reason
    - no **`indexOf` / `indexOfFirst`** inside the paging item factory
+   - the append branch handles **`LoadState.Error`** with a `retry()` footer, not only `LoadState.Loading`
+   - no **`lazyPagingItems[index]!!`** — null slots occur when `PagingConfig.enablePlaceholders = true`; check the null handling matches the config
 3. When keys are missing or index-based on a paginated feed, flag under Performance as **Paging list correctness** and recommend `compose-agent focus on paging`.
 4. When `LoadState.Error` is ignored or loading never resolves, flag under State management as **Paging load-state handling**.
 

--- a/skills/jetpack-compose-audit/references/search-playbook.md
+++ b/skills/jetpack-compose-audit/references/search-playbook.md
@@ -39,6 +39,7 @@ Search for:
 - `ComposeView`
 - `remember`
 - `mutableStateOf`
+- `collectAsLazyPagingItems|LazyPagingItems`
 
 If Compose usage is sparse, state that clearly in the report and reduce confidence.
 
@@ -202,6 +203,25 @@ There is no clean regex. Walk `items(..., key = ...)` / `itemsIndexed(..., key =
 - is the key computed from `hashCode()` on a non-`data class`?
 
 When uniqueness is not guaranteed, flag as a latent crash and suggest a dedup index or a synthesized key like `"${source}-${id}"`.
+
+### Paging-List Heuristic
+
+When `collectAsLazyPagingItems` / `LazyPagingItems` is present, paging-specific lazy-list bugs are in scope even if generic lazy-list searches were clean.
+
+1. Find paging UI files: `rg -l 'collectAsLazyPagingItems|LazyPagingItems' -g '*.kt'`
+2. For each hit, verify:
+   - `items(` / `itemsIndexed(` uses **`key =`** with stable domain ids (`itemKey { … }`), not index-only keys
+   - UI branches on **`loadState`** (refresh / append / error) — not a blank list during initial load or after failure
+   - **`refresh()`** / **`retry()`** are not invoked unconditionally from the composable body or a bare `LaunchedEffect(Unit)` without a documented one-shot reason
+   - no **`indexOf` / `indexOfFirst`** inside the paging item factory
+3. When keys are missing or index-based on a paginated feed, flag under Performance as **Paging list correctness** and recommend `compose-agent focus on paging`.
+4. When `LoadState.Error` is ignored or loading never resolves, flag under State management as **Paging load-state handling**.
+
+Positive signals to reward:
+
+- `items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey { it.id })`
+- top-level `when` on `loadState.refresh` / `loadState.append` with error retry via `lazyPagingItems.retry()`
+- pull-to-refresh wired to `lazyPagingItems.refresh()` on user action only
 
 ### Scaffold Inner-Padding Heuristic
 

--- a/skills/jetpack-compose-audit/references/search-playbook.md
+++ b/skills/jetpack-compose-audit/references/search-playbook.md
@@ -217,8 +217,10 @@ When `collectAsLazyPagingItems` / `LazyPagingItems` is present, paging-specific 
    - the append branch handles **`LoadState.Error`** with a `retry()` footer, not only `LoadState.Loading`
    - a full-screen `refresh is LoadState.Error` branch is **guarded by `itemCount == 0`** — otherwise a transient pull-to-refresh failure wipes an already-loaded feed
    - no **`lazyPagingItems[index]!!`** — null slots occur when `PagingConfig.enablePlaceholders = true`; check the null handling matches the config
-3. When keys are missing or index-based on a paginated feed, flag under Performance as **Paging list correctness** and recommend `compose-agent focus on paging`.
+   - no **`itemSnapshotList`** wired as the primary list source — it materializes the differ and defeats paging; treat as a list-correctness smell
+3. When keys are missing or index-based on a paginated feed, or `itemSnapshotList` drives the primary UI, flag under Performance as **Paging list correctness** and recommend `compose-agent focus on paging`.
 4. When `LoadState.Error` is ignored or loading never resolves, flag under State management as **Paging load-state handling**.
+5. When `refresh()` / `retry()` is invoked from composition or a bare `LaunchedEffect(Unit)`, flag under Side Effects as **Paging side-effect signals** (initial load is `PagingData`'s job; these are user-initiated).
 
 Positive signals to reward:
 
@@ -375,7 +377,7 @@ Positive signals to reward:
 - **strictly forbidden IO in a composable body** — serialization, network, database, file/directory IO, or subprocess work. `remember` is **not** a valid fix: the cached body still runs on the composition thread on first composition and on every key change. Threading-aware image loaders (Coil's `AsyncImage` / `rememberAsyncImagePainter`, Glide's Compose API) are the explicit carve-out
 - navigation, snackbar, analytics, or repository calls triggered during composition instead of from an effect or event path
 - `navController.navigate(...)` invoked in composition body — must come from an event handler or `LaunchedEffect`
-- `LaunchedEffect(Unit)` / `LaunchedEffect(true)` is **not** suspicious on its own (the "run once" pattern is idiomatic). Only flag it when the body captures parameter or state values that may change without `rememberUpdatedState`
+- `LaunchedEffect(Unit)` / `LaunchedEffect(true)` is **not** suspicious on its own (the "run once" pattern is idiomatic). Only flag it when the body captures parameter or state values that may change without `rememberUpdatedState` — **except** `LaunchedEffect(Unit) { lazyPagingItems.refresh() / retry() }`, which is a Side Effects defect (paged initial load is `PagingData`'s job; `refresh()`/`retry()` are user-initiated)
 - `DisposableEffect` with empty or suspicious cleanup
 - listener/observer registration without `onDispose`
 - effect keys too broad or too narrow


### PR DESCRIPTION
## Summary

- Adds `skills/compose-agent/references/paging.md` — LLM guardrails for Paging 3 in Compose (stable keys, `LoadState`, user-driven refresh/retry), not a `PagingSource` cookbook.
- Wires compose-agent review step #14, core/authoring guardrails, and manifest keyword `paging`.
- Extends jetpack-compose-audit with paging search heuristics and report signals (**Paging list correctness** under Performance, **Paging load-state handling** under State) without a fifth score category.
- Documents scope and multi-agent validation plan in `docs/paging-skill-plan.md`; release notes in `docs/release-notes-4.2.0.md`.

## Fixture convergence test (done)

Ran the validation step from `docs/paging-skill-plan.md`. Two fixtures, reviewed by fresh agents whose only paging knowledge was `paging.md`:

- **Buggy `FeedScreen.kt`** — index-only key, ignored `LoadState`, `refresh()` in `LaunchedEffect(Unit)`, `!!` on a paging slot, shadow `mutableStateOf(isLoading)`. → All three core bugs caught and cited to the right rule, plus the `!!`-crash and shadow-flag anti-patterns.
- **Negative control `SettingsScreen.kt`** (`StateFlow<List>`) — review refused to introduce Paging and cited the decision table.

Meets the GA criteria: key + LoadState bugs flagged, no RemoteMediator over-reach, no paging hallucination on the control.

### Refinements applied after the test (thesis-scoped, no PagingSource cookbook)

`paging.md`:
- Golden path now branches `append` Loading / Error(`retry()`) / else — the decision table promised the append-error affordance but the copy-paste recipe omitted it.
- New LLM tell: `collectAsStateWithLifecycle()` on a `Flow<PagingData<T>>` — the lifecycle rule from every other screen does not transfer; `collectAsLazyPagingItems()` is the only supported (already lifecycle-aware) collector.
- Null-slot contract tied to `PagingConfig.enablePlaceholders`: never `!!` a slot, no dead placeholder branch when placeholders are off, no non-null assumption when they are on.

`jetpack-compose-audit` (mirrored so the audit detects the same cases):
- Append `LoadState.Error` with no `retry()` footer → State deduction (**Paging load-state handling**).
- `lazyPagingItems[index]!!` / null-slot handling mismatched to `enablePlaceholders` → State deduction.
- Wired through `scoring.md`, `report-template.md`, `search-playbook.md`.

## Test plan

- [x] `./bin/ci` passes (manifest validation + paging smoke checks)
- [x] Run a paging review on a fixture with deliberate paging bugs (missing keys, ignored LoadState, composition-time refresh) — all three caught + cited
- [x] Audit the same fixture — paging findings land under Performance/State, not a new category
- [x] Negative control: `StateFlow<List>` screen did not surface paging rules
- [ ] Broader convergence pass across Codex / Cursor / other harnesses per `docs/paging-skill-plan.md`