### PR TITLE
Fix README install: use the real marketplace flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,21 +125,29 @@ This is the preferred path for Codex, Claude Code, Cursor, and multi-agent setup
 
 ### Claude Code plugin install
 
-Direct plugin install still works if you prefer Claude Code's plugin flow:
+Add this repository as a plugin marketplace, then install either plugin from it.
 
-```
-/plugin add hamen/compose_skill --subdir skills/jetpack-compose-audit
+From inside an interactive Claude Code session:
+
+```text
+/plugin marketplace add hamen/compose_skill
+/plugin install compose-agent@compose_skill
+/plugin install jetpack-compose-audit@compose_skill
 ```
 
-Claude Code reads `skills/jetpack-compose-audit/.claude-plugin/plugin.json` and registers `skills/jetpack-compose-audit/SKILL.md`. For `compose-agent`, use:
+Or from your shell:
 
+```bash
+claude plugin marketplace add hamen/compose_skill
+claude plugin install compose-agent@compose_skill
+claude plugin install jetpack-compose-audit@compose_skill
 ```
-/plugin add hamen/compose_skill --subdir skills/compose-agent
-```
+
+The root `.claude-plugin/marketplace.json` points each plugin at its `skills/<name>` subdir, where Claude Code reads `.claude-plugin/plugin.json` and registers `SKILL.md`.
 
 ### Breaking migration
 
-If you installed an older release with `--subdir compose-agent`, `--subdir jetpack-compose-audit`, or the nested `skills/<plugin>/skills/<name>` manual symlink, `/plugin update` will keep pointing at the old path. Remove that old install once and reinstall with the commands above.
+There is no `claude plugin add … --subdir` command — that form (documented in older releases) never worked. If you tried it, or installed via the nested `skills/<plugin>/skills/<name>` manual symlink, reinstall with the marketplace commands above.
 
 ### Manual symlink
 
@@ -287,8 +295,9 @@ npx --yes skills add hamen/compose_skill --skill compose-agent -y
 
 **Claude Code:**
 
-```
-/plugin add hamen/compose_skill --subdir skills/compose-agent
+```text
+/plugin marketplace add hamen/compose_skill
+/plugin install compose-agent@compose_skill
 ```
 
 **Cursor:** import the repo as a plugin and pick `compose-agent` in the subdirectory selector.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,14 @@ The root `.claude-plugin/marketplace.json` points each plugin at its `skills/<na
 
 ### Breaking migration
 
-There is no `claude plugin add … --subdir` command — that form (documented in older releases) never worked. If you tried it, or installed via the nested `skills/<plugin>/skills/<name>` manual symlink, reinstall with the marketplace commands above.
+The supported Claude Code flow is the `marketplace add` + `install` commands above. Note the `claude plugin` **CLI** has no `add` subcommand, so the shell form `claude plugin add … --subdir` does not work — use the marketplace commands instead.
+
+If you previously installed via an older `--subdir` path or the nested `skills/<plugin>/skills/<name>` manual symlink, **uninstall the old plugin first** (otherwise `/plugin update` keeps pointing at the stale path), then reinstall with the marketplace commands above:
+
+```text
+/plugin uninstall compose-agent
+/plugin uninstall jetpack-compose-audit
+```
 
 ### Manual symlink
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,20 @@ The root `.claude-plugin/marketplace.json` points each plugin at its `skills/<na
 
 The supported Claude Code flow is the `marketplace add` + `install` commands above. Note the `claude plugin` **CLI** has no `add` subcommand, so the shell form `claude plugin add … --subdir` does not work — use the marketplace commands instead.
 
-If you previously installed via an older `--subdir` path or the nested `skills/<plugin>/skills/<name>` manual symlink, **uninstall the old plugin first** (otherwise `/plugin update` keeps pointing at the stale path), then reinstall with the marketplace commands above:
+If you previously installed via an older `--subdir` path or the nested `skills/<plugin>/skills/<name>` manual symlink, **uninstall the old plugin first** (otherwise `/plugin update` keeps pointing at the stale path), then reinstall with the marketplace commands above.
+
+From a Claude Code session:
 
 ```text
-/plugin uninstall compose-agent
-/plugin uninstall jetpack-compose-audit
+/plugin uninstall compose-agent@compose_skill
+/plugin uninstall jetpack-compose-audit@compose_skill
+```
+
+Or from your shell:
+
+```bash
+claude plugin uninstall compose-agent@compose_skill
+claude plugin uninstall jetpack-compose-audit@compose_skill
 ```
 
 ### Manual symlink

--- a/README.md
+++ b/README.md
@@ -151,19 +151,20 @@ The supported Claude Code flow is the `marketplace add` + `install` commands abo
 
 If you previously installed via an older `--subdir` path or the nested `skills/<plugin>/skills/<name>` manual symlink, **uninstall the old plugin first** (otherwise `/plugin update` keeps pointing at the stale path), then reinstall with the marketplace commands above.
 
-From a Claude Code session:
+First list what you have — a legacy install may appear under a different id than `@compose_skill`:
+
+```text
+/plugin list
+```
+
+Then uninstall whatever old entry it shows (use the exact id from the list), e.g.:
 
 ```text
 /plugin uninstall compose-agent@compose_skill
 /plugin uninstall jetpack-compose-audit@compose_skill
 ```
 
-Or from your shell:
-
-```bash
-claude plugin uninstall compose-agent@compose_skill
-claude plugin uninstall jetpack-compose-audit@compose_skill
-```
+The same commands work from your shell as `claude plugin list` and `claude plugin uninstall <id>`.
 
 ### Manual symlink
 


### PR DESCRIPTION
## Problem

The README documented Claude Code install as:

```
/plugin add hamen/compose_skill --subdir skills/compose-agent
```

But **`claude plugin add` is not a real command** — `add` isn't a `plugin` subcommand (verified against the CLI; only `marketplace add` and `install` exist). So this install path never worked, the same way `material-3-skill` #8 was broken.

## Fix

Replace both `/plugin add … --subdir` blocks (main install section + the sibling-skill section) with the actual flow:

```text
/plugin marketplace add hamen/compose_skill
/plugin install compose-agent@compose_skill
/plugin install jetpack-compose-audit@compose_skill
```

…and the `claude plugin …` shell equivalents. The breaking-migration note now points at the working commands. Historical `CHANGELOG.md` and `docs/release-notes-*.md` are intentionally left untouched.

This mirrors the fix shipped in `material-3-skill` v1.1.1.

## Verification

`bash bin/ci` passes (both plugin manifests validate via `claude plugin validate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)