### PR TITLE
docs(readme): "Made by" app links + Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-# Buttons shown at the top of the repo. Custom URL points to Ivan's hub (all apps).
-custom: ["https://ivanmorgillo.com/?utm_source=github&utm_medium=sponsor_button&utm_campaign=compose_skill"]
+# GitHub Sponsors button shown at the top of the repo.
+github: [hamen]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# Buttons shown at the top of the repo. Custom URL points to Ivan's hub (all apps).
+custom: ["https://ivanmorgillo.com/?utm_source=github&utm_medium=sponsor_button&utm_campaign=compose_skill"]

--- a/README.md
+++ b/README.md
@@ -461,6 +461,24 @@ skills/compose-agent/
 
 ---
 
+## Made by
+
+I'm **Ivan** — Android dev, creator of this skill. When I'm not writing Compose
+tooling, I ship small apps. If this saved you time, take one for a spin:
+
+- 🎯 **[3 Things a Day](https://3things.day/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — pick 3 things, finish them. That's the app.
+- 💪 **[StreakUp](https://streakup.fit/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — push-up, squat & pull-up streak tracker.
+- 🌙 **[Bedtime Stories](https://bedtimestories.click/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — AI bedtime stories your kid helps build.
+- 🃏 **[Blackjack Trainer 21](https://trainblackjack.app/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — learn perfect basic strategy with spaced repetition.
+- 📚 **[Ebooks for Kindle](https://kindlegratis.fun/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — free Kindle book deals, updated daily.
+- 🏊 **[Swimming Lane](https://swimminglane.app/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — swim lap & workout tracker.
+- 🥫 **[No Waste Food](https://nowastefood.app/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — track your pantry, stop wasting food.
+- 📱 **[Brainrot Tax](https://brainrottax.app/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — a reality check on your screen time.
+- 🖼️ **[Epic AI Wallpapers](https://cwti-ltd.github.io/ai-wallpapers/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — fresh AI wallpapers, every day.
+- 🧠 **[MyGoo](https://mygoo.fun/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill)** — daily trivia quiz game (Italian).
+
+Find me at [ivanmorgillo.com](https://ivanmorgillo.com/?utm_source=github&utm_medium=readme&utm_campaign=compose_skill) · [@hamen](https://x.com/hamen).
+
 ## License
 
 MIT.


### PR DESCRIPTION
Adds a **Made by** section at the end of the README linking all of Ivan's live app sites, and a `.github/FUNDING.yml` Sponsor button.

**Why:** the repo has a warm, high-trust dev audience. README/profile links are `nofollow` (no DR lift) but drive real **referral traffic + installs**, which is what ad/subscription-monetized apps need. UTM tags (`utm_campaign=compose_skill`) let GA4 attribute installs back to this repo.

**Changes**
- `README.md`: new `## Made by` section (10 app links + hub + X handle)
- `.github/FUNDING.yml`: Sponsor button → **GitHub Sponsors** (`github: [hamen]`), per cross-review (the button must target a funding destination, not a commercial hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDaGsxPqiYywmcQLuFQRuH